### PR TITLE
Allow static arrays in mass rate jumps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ PoissonRandom = "e409e4f3-bfea-5376-8464-e040bb5c01ab"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RandomNumbers = "e6cf234a-135c-5ec9-84dd-332b85af5143"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TreeViews = "a2a6695c-b41b-5b7d-aed9-dbfdeacea5d7"
 

--- a/src/DiffEqJump.jl
+++ b/src/DiffEqJump.jl
@@ -11,6 +11,7 @@ import Base: size, getindex, setindex!, length, similar, show
 import DataStructures: length, update!
 
 import RecursiveArrayTools: recursivecopy!
+using StaticArrays
 
 abstract type AbstractJump end
 abstract type AbstractAggregatorAlgorithm end

--- a/src/aggregators/direct.jl
+++ b/src/aggregators/direct.jl
@@ -72,7 +72,11 @@ end
 @inline function execute_jumps!(p::DirectJumpAggregation, integrator, u, params, t)
   num_ma_rates = get_num_majumps(p.ma_jumps)
   if p.next_jump <= num_ma_rates
+    if u isa SVector
+      integrator.u = executerx(u, p.next_jump, p.ma_jumps)
+    else
       @inbounds executerx!(u, p.next_jump, p.ma_jumps)
+    end
   else
       idx = p.next_jump - num_ma_rates
       @inbounds p.affects![idx](integrator)

--- a/src/aggregators/directcr.jl
+++ b/src/aggregators/directcr.jl
@@ -52,9 +52,9 @@ function DirectCRJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
     minexponent = exponent(minrate)
 
     # use the largest power of two that is <= the passed in minrate
-    minrate = 2.0^minexponent       
+    minrate = 2.0^minexponent
     ratetogroup = rate -> priortogid(rate, minexponent)
-    
+
     # construct an empty initial priority table -- we'll overwrite this in init anyways...
     rt = PriorityTable{T,Int,Int,typeof(ratetogroup)}(minrate, 2*minrate,
                                                         Vector{PriorityGroup{T,Vector{Int}}}(),
@@ -124,7 +124,11 @@ function execute_jumps!(p::DirectCRJumpAggregation, integrator, u, params, t)
     # execute jump
     num_ma_rates = get_num_majumps(p.ma_jumps)
     if p.next_jump <= num_ma_rates
-        @inbounds executerx!(u, p.next_jump, p.ma_jumps)
+        if u isa SVector
+          integrator.u = executerx(u, p.next_jump, p.ma_jumps)
+        else
+          @inbounds executerx!(u, p.next_jump, p.ma_jumps)
+        end
     else
         idx = p.next_jump - num_ma_rates
         @inbounds p.affects![idx](integrator)

--- a/src/aggregators/directcr.jl
+++ b/src/aggregators/directcr.jl
@@ -126,6 +126,7 @@ function execute_jumps!(p::DirectCRJumpAggregation, integrator, u, params, t)
     if p.next_jump <= num_ma_rates
         if u isa SVector
           integrator.u = executerx(u, p.next_jump, p.ma_jumps)
+          u = integrator.u
         else
           @inbounds executerx!(u, p.next_jump, p.ma_jumps)
         end

--- a/src/aggregators/nrm.jl
+++ b/src/aggregators/nrm.jl
@@ -88,6 +88,7 @@ function execute_jumps!(p::NRMJumpAggregation, integrator, u, params, t)
     if p.next_jump <= num_ma_rates
         if u isa SVector
           integrator.u = executerx(u, p.next_jump, p.ma_jumps)
+          u = integrator.u
         else
           @inbounds executerx!(u, p.next_jump, p.ma_jumps)
         end

--- a/src/aggregators/nrm.jl
+++ b/src/aggregators/nrm.jl
@@ -86,7 +86,11 @@ function execute_jumps!(p::NRMJumpAggregation, integrator, u, params, t)
     # execute jump
     num_ma_rates = get_num_majumps(p.ma_jumps)
     if p.next_jump <= num_ma_rates
-        @inbounds executerx!(u, p.next_jump, p.ma_jumps)
+        if u isa SVector
+          integrator.u = executerx(u, p.next_jump, p.ma_jumps)
+        else
+          @inbounds executerx!(u, p.next_jump, p.ma_jumps)
+        end
     else
         idx = p.next_jump - num_ma_rates
         @inbounds p.affects![idx](integrator)

--- a/src/aggregators/rssa.jl
+++ b/src/aggregators/rssa.jl
@@ -138,6 +138,7 @@ function execute_jumps!(p::RSSAJumpAggregation, integrator, u, params, t)
     if p.next_jump <= num_majumps
         if u isa SVector
           integrator.u = executerx(u, p.next_jump, p.ma_jumps)
+          u = integrator.u
         else
           @inbounds executerx!(u, p.next_jump, p.ma_jumps)
         end
@@ -145,6 +146,7 @@ function execute_jumps!(p::RSSAJumpAggregation, integrator, u, params, t)
         idx = p.next_jump - num_majumps
         @inbounds p.affects![idx](integrator)
     end
+
 
     # update bracketing intervals
     ubnds       = p.cur_u_bnds

--- a/src/aggregators/rssa.jl
+++ b/src/aggregators/rssa.jl
@@ -136,7 +136,11 @@ function execute_jumps!(p::RSSAJumpAggregation, integrator, u, params, t)
     majumps     = p.ma_jumps
     num_majumps = get_num_majumps(majumps)
     if p.next_jump <= num_majumps
-        @inbounds executerx!(u, p.next_jump, majumps)
+        if u isa SVector
+          integrator.u = executerx(u, p.next_jump, p.ma_jumps)
+        else
+          @inbounds executerx!(u, p.next_jump, p.ma_jumps)
+        end
     else
         idx = p.next_jump - num_majumps
         @inbounds p.affects![idx](integrator)
@@ -186,7 +190,7 @@ end
     if sum_rate < eps(sum_rate)
         p.next_jump = 0
         p.next_jump_time = convert(typeof(sum_rate), Inf)
-        return 
+        return
     end
 
     crlow       = p.cur_rate_low

--- a/src/aggregators/sortingdirect.jl
+++ b/src/aggregators/sortingdirect.jl
@@ -92,6 +92,7 @@ function execute_jumps!(p::SortingDirectJumpAggregation, integrator, u, params, 
     if p.next_jump <= num_ma_rates
         if u isa SVector
           integrator.u = executerx(u, p.next_jump, p.ma_jumps)
+          u = integrator.u
         else
           @inbounds executerx!(u, p.next_jump, p.ma_jumps)
         end

--- a/src/aggregators/sortingdirect.jl
+++ b/src/aggregators/sortingdirect.jl
@@ -90,7 +90,11 @@ function execute_jumps!(p::SortingDirectJumpAggregation, integrator, u, params, 
     # execute jump
     num_ma_rates = get_num_majumps(p.ma_jumps)
     if p.next_jump <= num_ma_rates
-        @inbounds executerx!(u, p.next_jump, p.ma_jumps)
+        if u isa SVector
+          integrator.u = executerx(u, p.next_jump, p.ma_jumps)
+        else
+          @inbounds executerx!(u, p.next_jump, p.ma_jumps)
+        end
     else
         idx = p.next_jump - num_ma_rates
         @inbounds p.affects![idx](integrator)

--- a/src/massaction_rates.jl
+++ b/src/massaction_rates.jl
@@ -4,9 +4,9 @@
 ###############################################################################
 
 @inline @fastmath function evalrxrate(speciesvec::AbstractVector{T}, rxidx::S,
-                              majump::MassActionJump{U,V,W})::R where {T,S,R,U <: AbstractVector{R},V,W} 
+                              majump::MassActionJump{U,V,W})::R where {T,S,R,U <: AbstractVector{R},V,W}
     val = one(T)
-    @inbounds for specstoch in majump.reactant_stoch[rxidx] 
+    @inbounds for specstoch in majump.reactant_stoch[rxidx]
         specpop = speciesvec[specstoch[1]]
         val    *= specpop
         @inbounds for k = 2:specstoch[2]
@@ -15,7 +15,7 @@
         end
     end
 
-    @inbounds return val * majump.scaled_rates[rxidx] 
+    @inbounds return val * majump.scaled_rates[rxidx]
 end
 
 @inline @fastmath function executerx!(speciesvec::AbstractVector{T}, rxidx::S,
@@ -25,6 +25,21 @@ end
         speciesvec[specstoch[1]] += specstoch[2]
     end
     nothing
+end
+
+@inline @fastmath function executerx!(speciesvec::SVector{T}, rxidx::S,
+                                      majump::MassActionJump{U,V,W}) where {T,S,U,V,W}
+    @inbounds net_stoch = majump.net_stoch[rxidx]
+
+    @inbounds for specstoch in net_stoch
+        speciesvec = setindex(speciesvec,speciesvec[specstoch[1]]+specstoch[2],specstoch[1])
+    end
+
+    #=
+    map(net_stoch) do stoch
+        @inbounds speciesvec[stoch[1]] + stoch[2]
+    end
+    =#
 end
 
 function scalerates!(unscaled_rates::AbstractVector{U}, stochmat::AbstractVector{V}) where {U,S,T,W <: Pair{S,T}, V <: AbstractVector{W}}
@@ -58,7 +73,7 @@ function spec_to_dep_rxs_map(numspec, ma_jumps::MassActionJump)
 
     # map from a species to reactions that depend on it
     spec_to_dep_rxs = [Set{Int}() for n = 1:numspec]
-    for rx in 1:numrxs                    
+    for rx in 1:numrxs
         for (spec,stoch) in ma_jumps.reactant_stoch[rx]
             push!(spec_to_dep_rxs[spec], rx)
         end

--- a/src/massaction_rates.jl
+++ b/src/massaction_rates.jl
@@ -27,13 +27,13 @@ end
     nothing
 end
 
-@inline @fastmath function executerx!(speciesvec::SVector{T}, rxidx::S,
+@inline @fastmath function executerx(speciesvec::SVector{T}, rxidx::S,
                                       majump::MassActionJump{U,V,W}) where {T,S,U,V,W}
     @inbounds net_stoch = majump.net_stoch[rxidx]
-
     @inbounds for specstoch in net_stoch
         speciesvec = setindex(speciesvec,speciesvec[specstoch[1]]+specstoch[2],specstoch[1])
     end
+    speciesvec
 
     #=
     map(net_stoch) do stoch

--- a/test/extinction_test.jl
+++ b/test/extinction_test.jl
@@ -1,12 +1,12 @@
-using DiffEqBase, DiffEqJump
+using DiffEqBase, DiffEqJump, StaticArrays
 using Test
 
-reactstoch = 
+reactstoch =
 [
     [1 => 1]
 ]
 
-netstoch = 
+netstoch =
 [
     [1 => -1]
 ]
@@ -21,6 +21,16 @@ dprob = DiscreteProblem(u0,(0.,10.),rates)
 
 
 algs = DiffEqJump.JUMP_AGGREGATORS
+
+for ssa in algs
+    jprob = JumpProblem(dprob, ssa, majump; vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
+    sol = solve(jprob, SSAStepper())
+    @test sol[1,end] == 0
+    @test sol.t[end] < Inf
+end
+
+u0 = SA[10]
+dprob = DiscreteProblem(u0,(0.,10.),rates)
 
 for ssa in algs
     jprob = JumpProblem(dprob, ssa, majump; vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)


### PR DESCRIPTION
This allows for static arrays to be used with mrj's for optimal speed on small problems.