### PR TITLE
Alias jumps by default in single threaded use

### DIFF
--- a/src/DiffEqJump.jl
+++ b/src/DiffEqJump.jl
@@ -11,7 +11,7 @@ import Base: size, getindex, setindex!, length, similar, show
 import DataStructures: length, update!
 
 import RecursiveArrayTools: recursivecopy!
-using StaticArrays
+using StaticArrays, Base.Threads
 
 abstract type AbstractJump end
 abstract type AbstractAggregatorAlgorithm end

--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -59,7 +59,7 @@ function DiffEqBase.__init(jump_prob::JumpProblem,
                          alg::SSAStepper;
                          save_start = true,
                          save_end = true,
-                         seed = seed_multiplier()*rand(UInt64),
+                         seed = nothing,
                          alias_jump = Threads.threadid() == 1,
                          saveat = nothing)
     if !(jump_prob.prob isa DiscreteProblem)
@@ -70,12 +70,18 @@ function DiffEqBase.__init(jump_prob::JumpProblem,
 
     if alias_jump
       cb = jump_prob.jump_callback.discrete_callbacks[1]
+      if seed !== nothing
+          Random.seed!(cb.condition.rng,seed)
+      end
     else
       cb = deepcopy(jump_prob.jump_callback.discrete_callbacks[1])
+      if seed === nothing
+          Random.seed!(cb.condition.rng,seed_multiplier()*rand(UInt64))
+      else
+          Random.seed!(cb.condition.rng,seed)
+      end
     end
 
-
-    Random.seed!(cb.condition.rng,seed)
     prob = jump_prob.prob
 
     if save_start

--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -60,16 +60,24 @@ function DiffEqBase.__init(jump_prob::JumpProblem,
                          save_start = true,
                          save_end = true,
                          seed = seed_multiplier()*rand(UInt64),
+                         alias_jump = Threads.threadid() == 1,
                          saveat = nothing)
     if !(jump_prob.prob isa DiscreteProblem)
         error("SSAStepper only supports DiscreteProblems.")
     end
     @assert isempty(jump_prob.jump_callback.continuous_callbacks)
     @assert length(jump_prob.jump_callback.discrete_callbacks) == 1
-    cb = deepcopy(jump_prob.jump_callback.discrete_callbacks[1])
+
+    if alias_jump
+      cb = jump_prob.jump_callback.discrete_callbacks[1]
+    else
+      cb = deepcopy(jump_prob.jump_callback.discrete_callbacks[1])
+    end
+
+
     Random.seed!(cb.condition.rng,seed)
     prob = jump_prob.prob
-    
+
     if save_start
         t = [prob.tspan[1]]
         u = [copy(prob.u0)]

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -11,10 +11,15 @@ end
 function DiffEqBase.__init(
   _jump_prob::DiffEqBase.AbstractJumpProblem{P},
   alg::DiffEqBase.DEAlgorithm,timeseries=[],ts=[],ks=[],recompile::Type{Val{recompile_flag}}=Val{true};
-  callback=nothing, seed = seed_multiplier()*rand(UInt64),
+  callback=nothing, seed = seed_multiplier()*rand(UInt64),alias_jump = Threads.threadid() == 1,
   kwargs...) where {P,recompile_flag}
 
-  jump_prob = resetted_jump_problem(_jump_prob,seed)
+  if alias_jump
+    jump_prob = _jump_prob
+    reset_jump_problem!(jump_prob,seed)
+  else
+    jump_prob = resetted_jump_problem(_jump_prob,seed)
+  end
 
   # DDEProblems do not have a recompile_flag argument
   if jump_prob.prob isa DiffEqBase.AbstractDDEProblem

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -11,7 +11,7 @@ end
 function DiffEqBase.__init(
   _jump_prob::DiffEqBase.AbstractJumpProblem{P},
   alg::DiffEqBase.DEAlgorithm,timeseries=[],ts=[],ks=[],recompile::Type{Val{recompile_flag}}=Val{true};
-  callback=nothing, seed = seed_multiplier()*rand(UInt64),alias_jump = Threads.threadid() == 1,
+  callback=nothing, seed = nothing,alias_jump = Threads.threadid() == 1,
   kwargs...) where {P,recompile_flag}
 
   if alias_jump
@@ -36,7 +36,11 @@ end
 function resetted_jump_problem(_jump_prob,seed)
   jump_prob = deepcopy(_jump_prob)
   if !isempty(jump_prob.jump_callback.discrete_callbacks)
-    Random.seed!(jump_prob.jump_callback.discrete_callbacks[1].condition.rng,seed)
+    if seed === nothing
+      Random.seed!(jump_prob.jump_callback.discrete_callbacks[1].condition.rng,seed_multiplier()*rand(UInt64))
+    else
+      Random.seed!(jump_prob.jump_callback.discrete_callbacks[1].condition.rng,seed)
+    end
   end
 
   if !isempty(jump_prob.variable_jumps)
@@ -48,7 +52,7 @@ function resetted_jump_problem(_jump_prob,seed)
 end
 
 function reset_jump_problem!(jump_prob,seed)
-  if !isempty(jump_prob.jump_callback.discrete_callbacks)
+  if seed !== nothing && !isempty(jump_prob.jump_callback.discrete_callbacks)
     Random.seed!(jump_prob.jump_callback.discrete_callbacks[1].condition.rng,seed)
   end
 


### PR DESCRIPTION
```julia
using DiffEqBase
using DiffEqJump
sr = [1.0,2.0,50.]
maj = MassActionJump(sr,[[1 => 1],[1 => 1],[0 => 1]], [[1 => 1], [1 => -1], [1 => 1]])
params = (1.0,2.0,50.)
tspan = (0.,4.)
u0 = [5]
dprob = DiscreteProblem(u0, tspan, params)
jprob = JumpProblem(dprob, Direct(), maj)
solve(EnsembleProblem(jprob), SSAStepper(), EnsembleThreads(); trajectories=10)
solve(EnsembleProblem(jprob;safetycopy=true), SSAStepper(), EnsembleThreads(); trajectories=10)

# From
@time for i in 1:10000 solve(EnsembleProblem(jprob), SSAStepper(), EnsembleThreads(); trajectories=1) end
1.907643 seconds (7.43 M allocations: 2.153 GiB, 11.64% gc time)
1.938158 seconds (7.42 M allocations: 2.153 GiB, 11.02% gc time)
1.908684 seconds (7.43 M allocations: 2.154 GiB, 11.19% gc time)
1.864572 seconds (7.43 M allocations: 2.154 GiB, 11.04% gc time)

# To
@time for i in 1:10000 solve(EnsembleProblem(jprob), SSAStepper(), EnsembleThreads(); trajectories=1) end
1.862159 seconds (7.06 M allocations: 2.128 GiB, 13.37% gc time)
1.723136 seconds (7.07 M allocations: 2.128 GiB, 12.32% gc time)
1.770109 seconds (7.08 M allocations: 2.130 GiB, 11.39% gc time)
1.632181 seconds (7.07 M allocations: 2.129 GiB, 10.78% gc time)
```