### PR TITLE
save last saveat point too

### DIFF
--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -39,7 +39,7 @@ function DiffEqBase.solve!(integrator)
 
     if integrator.saveat !== nothing && !isempty(integrator.saveat)
         # Split to help prediction
-        while integrator.cur_saveat < length(integrator.saveat) &&
+        while integrator.cur_saveat <= length(integrator.saveat) &&
            integrator.saveat[integrator.cur_saveat] < integrator.t
 
             push!(integrator.sol.t,integrator.saveat[integrator.cur_saveat])

--- a/test/ssa_tests.jl
+++ b/test/ssa_tests.jl
@@ -23,5 +23,5 @@ integrator.u[1]
 sol = solve(jump_prob,SSAStepper())
 
 jump_prob = JumpProblem(prob,Direct(),jump,jump2,save_positions=(false,false))
-sol = solve(jump_prob,SSAStepper(),saveat=0.0:0.1:3.0)
+sol = solve(jump_prob,SSAStepper(),saveat=0.0:0.1:2.9)
 @test sol.t == collect(0.0:0.1:3.0)


### PR DESCRIPTION
When putting in the kwarg passing for MT I noticed that if `saveat` ends before `tspan[2]` we weren't actually saving the final `saveat` point.