### PR TITLE
implement callback resets and DiscreteCallbacks in SSAStepper

### DIFF
--- a/src/DiffEqJump.jl
+++ b/src/DiffEqJump.jl
@@ -37,6 +37,7 @@ include("aggregators/rssa.jl")
 include("aggregators/prioritytable.jl")
 include("aggregators/directcr.jl")
 include("aggregators/rssacr.jl")
+include("aggregators/aggregated_api.jl")
 
 include("extended_jump_array.jl")
 include("problem.jl")
@@ -61,6 +62,8 @@ export RSSACR
 export get_num_majumps, needs_depgraph, needs_vartojumps_map
 
 export init, solve, solve!
+
+export reset_aggregated_jumps!
 
 export ExtendedJumpArray
 

--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -142,7 +142,7 @@ function DiffEqBase.step!(integrator::SSAIntegrator)
     if !isempty(integrator.tstops) &&
         integrator.tstops_idx <= length(integrator.tstops) &&
         integrator.tstops[integrator.tstops_idx] < integrator.tstop
-        
+
         integrator.t = integrator.tstops[integrator.tstops_idx]
         integrator.tstops_idx += 1
     else
@@ -150,7 +150,12 @@ function DiffEqBase.step!(integrator::SSAIntegrator)
         integrator.cb.affect!(integrator)
     end
 
-    discrete_modified,saved_in_cb = DiffEqBase.apply_discrete_callback!(integrator,integrator.opts.callback.discrete_callbacks...)
+    if !(typeof(integrator.opts.callback.discrete_callbacks)<:Tuple{})
+        discrete_modified,saved_in_cb = DiffEqBase.apply_discrete_callback!(integrator,integrator.opts.callback.discrete_callbacks...)
+    else
+        saved_in_cb = false
+    end
+
     !saved_in_cb && savevalues!(integrator)
     nothing
 end

--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -3,7 +3,7 @@
 
 struct SSAStepper <: DiffEqBase.DEAlgorithm end
 
-mutable struct SSAIntegrator{F,uType,tType,P,S,CB,SA} <: DiffEqBase.DEIntegrator{SSAStepper,Nothing,uType,tType}
+mutable struct SSAIntegrator{F,uType,tType,P,S,CB,SA,OPT,TS} <: DiffEqBase.DEIntegrator{SSAStepper,Nothing,uType,tType}
     f::F
     u::uType
     t::tType
@@ -16,6 +16,10 @@ mutable struct SSAIntegrator{F,uType,tType,P,S,CB,SA} <: DiffEqBase.DEIntegrator
     save_everystep::Bool
     save_end::Bool
     cur_saveat::Int
+    opts::OPT
+    tstops::TS
+    tstops_idx::Int
+    u_modified::Bool
 end
 
 (integrator::SSAIntegrator)(t) = copy(integrator.u)
@@ -61,20 +65,21 @@ function DiffEqBase.__init(jump_prob::JumpProblem,
                          save_end = true,
                          seed = nothing,
                          alias_jump = Threads.threadid() == 1,
-                         saveat = nothing)
+                         saveat = nothing,
+                         callback = nothing,
+                         tstops = ())
     if !(jump_prob.prob isa DiscreteProblem)
         error("SSAStepper only supports DiscreteProblems.")
     end
     @assert isempty(jump_prob.jump_callback.continuous_callbacks)
-    @assert length(jump_prob.jump_callback.discrete_callbacks) == 1
 
     if alias_jump
-      cb = jump_prob.jump_callback.discrete_callbacks[1]
+      cb = jump_prob.jump_callback.discrete_callbacks[end]
       if seed !== nothing
           Random.seed!(cb.condition.rng,seed)
       end
     else
-      cb = deepcopy(jump_prob.jump_callback.discrete_callbacks[1])
+      cb = deepcopy(jump_prob.jump_callback.discrete_callbacks[end])
       if seed === nothing
           Random.seed!(cb.condition.rng,seed_multiplier()*rand(UInt64))
       else
@@ -82,6 +87,7 @@ function DiffEqBase.__init(jump_prob::JumpProblem,
       end
     end
 
+    opts = (callback = CallbackSet(callback),)
     prob = jump_prob.prob
 
     if save_start
@@ -91,8 +97,11 @@ function DiffEqBase.__init(jump_prob::JumpProblem,
         t = typeof(prob.tspan[1])[]
         u = typeof(prob.u0)[]
     end
+
+
     sol = DiffEqBase.build_solution(prob,alg,t,u,dense=false,
                          calculate_error = false,
+                         destats = DiffEqBase.DEStats(0),
                          interp = DiffEqBase.ConstantInterpolation(t,u))
     save_everystep = any(cb.save_positions)
 
@@ -121,18 +130,35 @@ function DiffEqBase.__init(jump_prob::JumpProblem,
 
     integrator = SSAIntegrator(prob.f,copy(prob.u0),prob.tspan[1],prob.p,
                                sol,1,prob.tspan[1],
-                               cb,_saveat,save_everystep,save_end,cur_saveat)
+                               cb,_saveat,save_everystep,save_end,cur_saveat,
+                               opts,tstops,1,false)
     cb.initialize(cb,u[1],prob.tspan[1],integrator)
-
     integrator
 end
 
 DiffEqBase.add_tstop!(integrator::SSAIntegrator,tstop) = integrator.tstop = tstop
 
 function DiffEqBase.step!(integrator::SSAIntegrator)
-    integrator.t = integrator.tstop
-    integrator.cb.affect!(integrator)
-    if integrator.save_everystep
+    if !isempty(integrator.tstops) &&
+        integrator.tstops_idx <= length(integrator.tstops) &&
+        integrator.tstops[integrator.tstops_idx] < integrator.tstop
+        
+        integrator.t = integrator.tstops[integrator.tstops_idx]
+        integrator.tstops_idx += 1
+    else
+        integrator.t = integrator.tstop
+        integrator.cb.affect!(integrator)
+    end
+
+    discrete_modified,saved_in_cb = DiffEqBase.apply_discrete_callback!(integrator,integrator.opts.callback.discrete_callbacks...)
+    !saved_in_cb && savevalues!(integrator)
+    nothing
+end
+
+function DiffEqBase.savevalues!(integrator::SSAIntegrator,force=false)
+    saved, savedexactly = false, false
+    if integrator.save_everystep || force
+        savedexactly = true
         push!(integrator.sol.t,integrator.t)
         push!(integrator.sol.u,copy(integrator.u))
     end
@@ -141,13 +167,14 @@ function DiffEqBase.step!(integrator::SSAIntegrator)
         while integrator.cur_saveat < length(integrator.saveat) &&
            integrator.saveat[integrator.cur_saveat] < integrator.t
 
+            saved = true
             push!(integrator.sol.t,integrator.saveat[integrator.cur_saveat])
             push!(integrator.sol.u,copy(integrator.u))
             integrator.cur_saveat += 1
 
         end
     end
-    nothing
+    saved, savedexactly
 end
 
 export SSAStepper

--- a/src/aggregators/aggregated_api.jl
+++ b/src/aggregators/aggregated_api.jl
@@ -1,0 +1,29 @@
+function reset_aggregated_jumps!(integrator,uprev = nothing)
+     reset_aggregated_jumps!(integrator,uprev,integrator.opts.callback)
+     nothing
+end
+
+function reset_aggregated_jumps!(integrator,uprev,callback::CallbackSet)
+    if !isempty(callback.discrete_callbacks)
+        reset_aggregated_jumps!(integrator,uprev,callback.discrete_callbacks...)
+    end
+    nothing
+end
+
+function reset_aggregated_jumps!(integrator,uprev,cb::DiscreteCallback,cbs...)
+    reset_aggregated_jumps!(integrator,uprev,cbs...)
+    nothing
+end
+
+reset_aggregated_jumps!(integrator,uprev,cb::DiscreteCallback) = nothing
+
+function reset_aggregated_jumps!(integrator,uprev,cb::AbstractSSAJumpAggregator,cbs...)
+    cb(cb,integrator.u,t,integrator) # This overload is the aggregated cb's init
+    reset_aggregated_jumps!(integrator,uprev,cbs...)
+    nothing
+end
+
+function reset_aggregated_jumps!(integrator,uprev,cb::AbstractSSAJumpAggregator)
+    reset_aggregated_jumps!(integrator,uprev,cbs...)
+    nothing
+end

--- a/src/aggregators/aggregated_api.jl
+++ b/src/aggregators/aggregated_api.jl
@@ -3,6 +3,11 @@ function reset_aggregated_jumps!(integrator,uprev = nothing)
      nothing
 end
 
+function reset_aggregated_jumps!(integrator,uprev,callback::Nothing)
+     nothing
+end
+
+
 function reset_aggregated_jumps!(integrator,uprev,callback::CallbackSet)
     if !isempty(callback.discrete_callbacks)
         reset_aggregated_jumps!(integrator,uprev,callback.discrete_callbacks...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using DiffEqJump, DiffEqBase, Test
   @time @testset "Split Coupled Tests" begin include("splitcoupled.jl") end
   @time @testset "SSA Tests" begin include("ssa_tests.jl") end
   @time @testset "Tau Leaping Tests" begin include("regular_jumps.jl") end
+  @time @testset "SIR Discrete Callback Test" begin include("sir_model.jl") end
   @time @testset "Linear Reaction SSA Test" begin include("linearreaction_test.jl") end
   @time @testset "Mass Action Jump Tests; Gene Expr Model" begin include("geneexpr_test.jl") end
   @time @testset "Mass Action Jump Tests; Nonlinear Rx Model" begin include("bimolerx_test.jl") end


### PR DESCRIPTION
Right now it requires that the user knows to call `reset_aggregated_jumps!`. This can be fixed by hoisting this call all the way up to DiffEqBase and into `apply_discrete_callback!`, which is a bit of work so I'm punting on that for now but will open an issue.

Fixes https://github.com/SciML/DiffEqJump.jl/issues/119 and mostly fixes https://github.com/SciML/DiffEqJump.jl/issues/78 . For the latter, you cannot add `tstops!` on the fly in a DiscreteCallback, so it doesn't fully conform to the interface, but it's close.