### PR TITLE
add option for MassActionJumps to modify inputs

### DIFF
--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -58,9 +58,9 @@ struct MassActionJump{T,S,U} <: AbstractJump
   reactant_stoch::S
   net_stoch::U
 
-  function MassActionJump{T,S,U}(rates::T, rs_in::S, ns::U, scale_rates::Bool, useiszero::Bool) where {T <: AbstractVector, S, U}
-    sr  = copy(rates)
-    rs = copy(rs_in)
+  function MassActionJump{T,S,U}(rates::T, rs_in::S, ns::U, scale_rates::Bool, useiszero::Bool, nocopy::Bool) where {T <: AbstractVector, S, U}
+    sr  = nocopy ? rates : copy(rates)
+    rs = nocopy ? rs_in : copy(rs_in)
     for i in eachindex(rs)
       if useiszero && (length(rs[i]) == 1) && iszero(rs[i][1][1])
         rs[i] = typeof(rs[i])()
@@ -72,7 +72,7 @@ struct MassActionJump{T,S,U} <: AbstractJump
     end
     new(sr, rs, ns)
   end
-  function MassActionJump{T,S,U}(rate::T, rs_in::S, ns::U, scale_rates::Bool, useiszero::Bool) where {T <: Number, S, U}
+  function MassActionJump{T,S,U}(rate::T, rs_in::S, ns::U, scale_rates::Bool, useiszero::Bool, nocopy::Bool) where {T <: Number, S, U}
     rs = rs_in
     if useiszero && (length(rs) == 1) && iszero(rs[1][1])
       rs = typeof(rs)()
@@ -82,7 +82,7 @@ struct MassActionJump{T,S,U} <: AbstractJump
   end
 
 end
-MassActionJump(usr::T, rs::S, ns::U; scale_rates = true, useiszero = true) where {T,S,U} = MassActionJump{T,S,U}(usr, rs, ns, scale_rates, useiszero)
+MassActionJump(usr::T, rs::S, ns::U; scale_rates = true, useiszero = true, nocopy=false) where {T,S,U} = MassActionJump{T,S,U}(usr, rs, ns, scale_rates, useiszero, nocopy)
 
 @inline get_num_majumps(maj::MassActionJump) = length(maj.scaled_rates)
 @inline get_num_majumps(maj::Nothing) = 0


### PR DESCRIPTION
Add an option for `MassActionJump`s to modify passed in rate vectors and stoichiometries as needed. We should be able to exploit this in MT to reduce allocations.