### PR TITLE
some cleanup, fixes and extensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,14 +10,13 @@ DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 FunctionWrappers = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 PoissonRandom = "e409e4f3-bfea-5376-8464-e040bb5c01ab"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 RandomNumbers = "e6cf234a-135c-5ec9-84dd-332b85af5143"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TreeViews = "a2a6695c-b41b-5b7d-aed9-dbfdeacea5d7"
+UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 ArrayInterface = "2.8"
@@ -25,20 +24,19 @@ Compat = "2.2, 3.0"
 DataStructures = "0.17"
 DiffEqBase = "6.11"
 FunctionWrappers = "1.0"
-Parameters = "0.12"
 PoissonRandom = "0.4"
 RandomNumbers = "1.3"
 RecursiveArrayTools = "2"
 StaticArrays = "0.10, 0.11, 0.12"
 TreeViews = "0.3"
+UnPack = "1.0.1"
 julia = "1.3"
 
 [extras]
-DiffEqProblemLibrary = "a077e3f3-b75c-5d7f-a0c6-6bc4c8ec64a9"
-Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DiffEqProblemLibrary", "Distributions", "OrdinaryDiffEq", "StochasticDiffEq", "Test"]
+test = ["OrdinaryDiffEq", "Statistics", "StochasticDiffEq", "Test"]

--- a/src/DiffEqJump.jl
+++ b/src/DiffEqJump.jl
@@ -4,7 +4,7 @@ module DiffEqJump
 
 using DiffEqBase, Compat, RandomNumbers, TreeViews, LinearAlgebra
 using DataStructures, PoissonRandom, Random, ArrayInterface
-using FunctionWrappers, Parameters
+using FunctionWrappers, UnPack
 
 import DiffEqBase: DiscreteCallback, init, solve, solve!, plot_indices
 import Base: size, getindex, setindex!, length, similar, show

--- a/src/aggregators/aggregators.jl
+++ b/src/aggregators/aggregators.jl
@@ -64,11 +64,20 @@ systems with many species and many channels, Journal of Physical Chemistry A,
 104 (9), 1876-1889 (2000). doi:10.1021/jp993732q
 """
 struct NRM <: AbstractAggregatorAlgorithm end
+
+"""
+V. H. Thanh, R. Zunino, and C. Priami, Efficient Constant-Time Complexity
+Algorithm for Stochastic Simulation of Large Reaction Networks, IEEE/ACM
+Transactions on Computational Biology and Bioinformatics, Vol. 14, No. 3,
+657-667 (2017).
+"""
 struct RSSACR <: AbstractAggregatorAlgorithm end
+
+
 struct RDirect <: AbstractAggregatorAlgorithm end
 
 
-const JUMP_AGGREGATORS = (Direct(),DirectFW(),DirectCR(),SortingDirect(),RSSA(),FRM(),FRMFW(),NRM(),RSSACR(), RDirect())
+const JUMP_AGGREGATORS = (Direct(),DirectFW(),DirectCR(),SortingDirect(),RSSA(),FRM(),FRMFW(),NRM(),RSSACR(),RDirect())
 
 # For JumpProblem construction without an aggregator
 struct NullAggregator <: AbstractAggregatorAlgorithm end

--- a/src/aggregators/aggregators.jl
+++ b/src/aggregators/aggregators.jl
@@ -1,5 +1,7 @@
 # define new aggregator algorithms here and specify their properties
 
+# Direct type methods
+
 """
 Gillespie, Daniel T. (1976). A General Method for Numerically Simulating the
 Stochastic Time Evolution of Coupled Chemical Reactions. Journal of
@@ -45,6 +47,18 @@ struct SortingDirect <: AbstractAggregatorAlgorithm end
 struct RSSA <: AbstractAggregatorAlgorithm end
 
 """
+V. H. Thanh, R. Zunino, and C. Priami, Efficient Constant-Time Complexity
+Algorithm for Stochastic Simulation of Large Reaction Networks, IEEE/ACM
+Transactions on Computational Biology and Bioinformatics, Vol. 14, No. 3,
+657-667 (2017).
+"""
+struct RSSACR <: AbstractAggregatorAlgorithm end
+
+struct RDirect <: AbstractAggregatorAlgorithm end
+
+# NRM-based methods
+
+"""
 Gillespie, Daniel T. (1976). A General Method for Numerically Simulating the
 Stochastic Time Evolution of Coupled Chemical Reactions. Journal of
 Computational Physics. 22 (4): 403–434. doi:10.1016/0021-9991(76)90041-3.
@@ -64,17 +78,6 @@ systems with many species and many channels, Journal of Physical Chemistry A,
 104 (9), 1876-1889 (2000). doi:10.1021/jp993732q
 """
 struct NRM <: AbstractAggregatorAlgorithm end
-
-"""
-V. H. Thanh, R. Zunino, and C. Priami, Efficient Constant-Time Complexity
-Algorithm for Stochastic Simulation of Large Reaction Networks, IEEE/ACM
-Transactions on Computational Biology and Bioinformatics, Vol. 14, No. 3,
-657-667 (2017).
-"""
-struct RSSACR <: AbstractAggregatorAlgorithm end
-
-
-struct RDirect <: AbstractAggregatorAlgorithm end
 
 
 const JUMP_AGGREGATORS = (Direct(),DirectFW(),DirectCR(),SortingDirect(),RSSA(),FRM(),FRMFW(),NRM(),RSSACR(),RDirect())

--- a/src/aggregators/direct.jl
+++ b/src/aggregators/direct.jl
@@ -16,28 +16,6 @@ DirectJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, rs:
   DirectJumpAggregation{T,S,F1,F2,RNG}(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng)
 
 
-########### The following routines should be templates for all SSAs ###########
-
-# condition for jump to occur
-@inline function (p::DirectJumpAggregation)(u, t, integrator)
-  p.next_jump_time == t
-end
-
-# executing jump at the next jump time
-function (p::DirectJumpAggregation)(integrator)
-  execute_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
-  generate_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
-  register_next_jump_time!(integrator, p, integrator.t)
-  nothing
-end
-
-# setting up a new simulation
-function (p::DirectJumpAggregation)(dj, u, t, integrator) # initialize
-  initialize!(p, integrator, u, integrator.p, t)
-  register_next_jump_time!(integrator, p, t)
-  nothing
-end
-
 ############################# Required Functions #############################
 
 # creating the JumpAggregation structure (tuple-based constant jumps)

--- a/src/aggregators/direct.jl
+++ b/src/aggregators/direct.jl
@@ -1,5 +1,6 @@
 mutable struct DirectJumpAggregation{T,S,F1,F2,RNG} <: AbstractSSAJumpAggregator
   next_jump::Int
+  prev_jump::Int
   next_jump_time::T
   end_time::T
   cur_rates::Vector{T}
@@ -9,11 +10,9 @@ mutable struct DirectJumpAggregation{T,S,F1,F2,RNG} <: AbstractSSAJumpAggregator
   affects!::F2
   save_positions::Tuple{Bool,Bool}
   rng::RNG
-  DirectJumpAggregation{T,S,F1,F2,RNG}(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, rs::F1, affs!::F2, sps::Tuple{Bool,Bool}, rng::RNG) where {T,S,F1,F2,RNG} =
-    new{T,S,F1,F2,RNG}(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng)
 end
 DirectJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, rs::F1, affs!::F2, sps::Tuple{Bool,Bool}, rng::RNG; kwargs...) where {T,S,F1,F2,RNG} =
-  DirectJumpAggregation{T,S,F1,F2,RNG}(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng)
+  DirectJumpAggregation{T,S,F1,F2,RNG}(nj, nj, njt, et, crs, sr, maj, rs, affs!, sps, rng)
 
 
 ############################# Required Functions #############################

--- a/src/aggregators/directcr.jl
+++ b/src/aggregators/directcr.jl
@@ -12,6 +12,7 @@ const MINJUMPRATE = 2.0^exponent(1e-12)
 
 mutable struct DirectCRJumpAggregation{T,S,F1,F2,RNG,DEPGR,U<:PriorityTable,W<:Function} <: AbstractSSAJumpAggregator
     next_jump::Int
+    prev_jump::Int
     next_jump_time::T
     end_time::T
     cur_rates::Vector{T}
@@ -62,7 +63,7 @@ function DirectCRJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
                                                         Vector{Tuple{Int,Int}}(), ratetogroup)
 
     DirectCRJumpAggregation{T,S,F1,F2,RNG,typeof(dg),typeof(rt),typeof(ratetogroup)}(
-                                            nj, njt, et, crs, sr, maj, rs, affs!, sps, rng,
+                                            nj, nj, njt, et, crs, sr, maj, rs, affs!, sps, rng,
                                             dg, minrate, maxrate, rt, ratetogroup)
 end
 

--- a/src/aggregators/directcr.jl
+++ b/src/aggregators/directcr.jl
@@ -67,29 +67,6 @@ function DirectCRJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
 end
 
 
-
-########### The following routines should be templates for all SSAs ###########
-
-# condition for jump to occur
-@inline function (p::DirectCRJumpAggregation)(u, t, integrator)
-    p.next_jump_time == t
-end
-
-# executing jump at the next jump time
-function (p::DirectCRJumpAggregation)(integrator)
-    execute_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
-    generate_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
-    register_next_jump_time!(integrator, p, integrator.t)
-    nothing
-end
-
-# setting up a new simulation
-function (p::DirectCRJumpAggregation)(dj, u, t, integrator) # initialize
-    initialize!(p, integrator, u, integrator.p, t)
-    register_next_jump_time!(integrator, p, t)
-    nothing
-end
-
 ############################# Required Functions ##############################
 
 # creating the JumpAggregation structure (function wrapper-based constant jumps)

--- a/src/aggregators/frm.jl
+++ b/src/aggregators/frm.jl
@@ -16,28 +16,6 @@ FRMJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, rs::F1
     FRMJumpAggregation{T,S,F1,F2,RNG}(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng)
 
 
-########### The following routines should be templates for all SSAs ###########
-
-# condition for jump to occur
-@inline function (p::FRMJumpAggregation)(u, t, integrator)
-  p.next_jump_time == t
-end
-
-# executing jump at the next jump time
-function (p::FRMJumpAggregation)(integrator)
-  execute_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
-  generate_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
-  register_next_jump_time!(integrator, p, integrator.t)
-  nothing
-end
-
-# setting up a new simulation
-function (p::FRMJumpAggregation)(dj, u, t, integrator) # initialize
-  initialize!(p, integrator, u, integrator.p, t)
-  register_next_jump_time!(integrator, p, t)
-  nothing
-end
-
 ############################# Required Functions #############################
 
 # creating the JumpAggregation structure (tuple-based constant jumps)

--- a/src/aggregators/frm.jl
+++ b/src/aggregators/frm.jl
@@ -1,5 +1,6 @@
 mutable struct FRMJumpAggregation{T,S,F1,F2,RNG} <: AbstractSSAJumpAggregator
   next_jump::Int
+  prev_jump::Int
   next_jump_time::T
   end_time::T
   cur_rates::Vector{T}
@@ -9,11 +10,9 @@ mutable struct FRMJumpAggregation{T,S,F1,F2,RNG} <: AbstractSSAJumpAggregator
   affects!::F2
   save_positions::Tuple{Bool,Bool}
   rng::RNG
-  FRMJumpAggregation{T,S,F1,F2,RNG}(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, rs::F1, affs!::F2, sps::Tuple{Bool,Bool}, rng::RNG) where {T,S,F1,F2,RNG} =
-    new{T,S,F1,F2,RNG}(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng)
 end
 FRMJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, rs::F1, affs!::F2, sps::Tuple{Bool,Bool}, rng::RNG; kwargs...) where {T,S,F1,F2,RNG} =
-    FRMJumpAggregation{T,S,F1,F2,RNG}(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng)
+    FRMJumpAggregation{T,S,F1,F2,RNG}(nj, nj, njt, et, crs, sr, maj, rs, affs!, sps, rng)
 
 
 ############################# Required Functions #############################

--- a/src/aggregators/nrm.jl
+++ b/src/aggregators/nrm.jl
@@ -39,29 +39,6 @@ function NRMJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
     NRMJumpAggregation{T,S,F1,F2,RNG,typeof(dg),typeof(pq)}(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng, dg, pq)
 end
 
-########### The following routines should be templates for all SSAs ###########
-
-# condition for jump to occur
-@inline function (p::NRMJumpAggregation)(u, t, integrator)
-    p.next_jump_time == t
-end
-
-# executing jump at the next jump time
-function (p::NRMJumpAggregation)(integrator)
-    execute_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
-    generate_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
-    register_next_jump_time!(integrator, p, integrator.t)
-    nothing
-end
-
-# setting up a new simulation
-function (p::NRMJumpAggregation)(dj, u, t, integrator) # initialize
-    initialize!(p, integrator, u, integrator.p, t)
-    register_next_jump_time!(integrator, p, t)
-    nothing
-end
-
-
 +############################# Required Functions ##############################
 # creating the JumpAggregation structure (function wrapper-based constant jumps)
 function aggregate(aggregator::NRM, u, p, t, end_time, constant_jumps,

--- a/src/aggregators/nrm.jl
+++ b/src/aggregators/nrm.jl
@@ -3,6 +3,7 @@
 
 mutable struct NRMJumpAggregation{T,S,F1,F2,RNG,DEPGR,PQ} <: AbstractSSAJumpAggregator
     next_jump::Int
+    prev_jump::Int
     next_jump_time::T
     end_time::T
     cur_rates::Vector{T}
@@ -36,7 +37,8 @@ function NRMJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
 
     pq = MutableBinaryMinHeap{T}()
 
-    NRMJumpAggregation{T,S,F1,F2,RNG,typeof(dg),typeof(pq)}(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng, dg, pq)
+    NRMJumpAggregation{T,S,F1,F2,RNG,typeof(dg),typeof(pq)}(nj, nj, njt, et, crs, sr, maj, 
+                                                            rs, affs!, sps, rng, dg, pq)
 end
 
 +############################# Required Functions ##############################

--- a/src/aggregators/rdirect.jl
+++ b/src/aggregators/rdirect.jl
@@ -4,6 +4,7 @@ Direct with rejection sampling
 
 mutable struct RDirectJumpAggregation{T,S,F1,F2,RNG,DEPGR} <: AbstractSSAJumpAggregator
   next_jump::Int
+  prev_jump::Int
   next_jump_time::T
   end_time::T
   cur_rates::Vector{T}
@@ -17,8 +18,9 @@ mutable struct RDirectJumpAggregation{T,S,F1,F2,RNG,DEPGR} <: AbstractSSAJumpAgg
   max_rate::T
 end
 
-
-function RDirectJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, rs::F1, affs!::F2, sps::Tuple{Bool,Bool}, rng::RNG; num_specs, dep_graph=nothing, kwargs...) where {T,S,F1,F2,RNG,DEPGR}
+function RDirectJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, maj::S, 
+                                rs::F1, affs!::F2, sps::Tuple{Bool,Bool}, rng::RNG; 
+                                num_specs, dep_graph=nothing, kwargs...) where {T,S,F1,F2,RNG,DEPGR}
     # a dependency graph is needed and must be provided if there are constant rate jumps
     if dep_graph === nothing
         if (get_num_majumps(maj) == 0) || !isempty(rs)
@@ -33,7 +35,8 @@ function RDirectJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, m
     # make sure each jump depends on itself
     add_self_dependencies!(dg)
     max_rate = maximum(crs)
-    return RDirectJumpAggregation{T,S,F1,F2,RNG,typeof(dg)}(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng, dg, max_rate)
+    return RDirectJumpAggregation{T,S,F1,F2,RNG,typeof(dg)}(nj, nj, njt, et, crs, sr, maj, rs, 
+                                                            affs!, sps, rng, dg, max_rate)
 end
 
 ############################# Required Functions #############################

--- a/src/aggregators/rdirect.jl
+++ b/src/aggregators/rdirect.jl
@@ -36,28 +36,6 @@ function RDirectJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, m
     return RDirectJumpAggregation{T,S,F1,F2,RNG,typeof(dg)}(nj, njt, et, crs, sr, maj, rs, affs!, sps, rng, dg, max_rate)
 end
 
-########### The following routines should be templates for all SSAs ###########
-
-# condition for jump to occur
-@inline function (p::RDirectJumpAggregation)(u, t, integrator)
-  p.next_jump_time == t
-end
-
-# executing jump at the next jump time
-function (p::RDirectJumpAggregation)(integrator)
-  execute_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
-  generate_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
-  register_next_jump_time!(integrator, p, integrator.t)
-  nothing
-end
-
-# setting up a new simulation
-function (p::RDirectJumpAggregation)(dj, u, t, integrator) # initialize
-  initialize!(p, integrator, u, integrator.p, t)
-  register_next_jump_time!(integrator, p, t)
-  nothing
-end
-
 ############################# Required Functions #############################
 
 # creating the JumpAggregation structure (tuple-based constant jumps)

--- a/src/aggregators/rssa.jl
+++ b/src/aggregators/rssa.jl
@@ -6,6 +6,7 @@
 
 mutable struct RSSAJumpAggregation{T,T2,S,F1,F2,RNG,VJMAP,JVMAP,BD,T2V} <: AbstractSSAJumpAggregator
     next_jump::Int
+    prev_jump::Int
     next_jump_time::T
     end_time::T
     cur_rate_low::Vector{T}
@@ -55,7 +56,7 @@ mutable struct RSSAJumpAggregation{T,T2,S,F1,F2,RNG,VJMAP,JVMAP,BD,T2V} <: Abstr
     uhigh   = @view cs_bnds[2,:]
 
     RSSAJumpAggregation{T,eltype(U),S,F1,F2,RNG,typeof(vtoj_map),typeof(jtov_map),typeof(bd),typeof(ulow)}(
-                        nj, njt, et, crl_bnds, crh_bnds, sr, cs_bnds, maj, rs,
+                        nj, nj, njt, et, crl_bnds, crh_bnds, sr, cs_bnds, maj, rs,
                         affs!, sps, rng, vtoj_map, jtov_map, bd, ulow, uhigh)
 end
 

--- a/src/aggregators/rssa.jl
+++ b/src/aggregators/rssa.jl
@@ -59,29 +59,6 @@ mutable struct RSSAJumpAggregation{T,T2,S,F1,F2,RNG,VJMAP,JVMAP,BD,T2V} <: Abstr
                         affs!, sps, rng, vtoj_map, jtov_map, bd, ulow, uhigh)
 end
 
-
-########### The following routines should be templates for all SSAs ###########
-
-# condition for jump to occur
-@inline function (p::RSSAJumpAggregation)(u, t, integrator)
-    p.next_jump_time == t
-end
-
-# executing jump at the next jump time
-function (p::RSSAJumpAggregation)(integrator)
-    execute_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
-    generate_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
-    register_next_jump_time!(integrator, p, integrator.t)
-    nothing
-end
-
-# setting up a new simulation
-function (p::RSSAJumpAggregation)(dj, u, t, integrator) # initialize
-    initialize!(p, integrator, u, integrator.p, t)
-    register_next_jump_time!(integrator, p, t)
-    nothing
-end
-
 ############################# Required Functions ##############################
 
 # creating the JumpAggregation structure (function wrapper-based constant jumps)

--- a/src/aggregators/rssacr.jl
+++ b/src/aggregators/rssacr.jl
@@ -67,28 +67,6 @@ function RSSACRJumpAggregation(nj::Int, njt::F, et::F, crs::Vector{F}, sum_rate:
     RSSACRJumpAggregation{typeof(njt),eltype(U),S,F1,F2,RNG,typeof(vtoj_map),typeof(jtov_map),typeof(bd),typeof(ulow),typeof(rt),typeof(ratetogroup)}(nj, njt, et, crl_bnds, crh_bnds, sum_rate, maj, rs, affs!, sps, rng, vtoj_map, jtov_map, bd, ulow, uhigh, minrate, maxrate, rt, ratetogroup, cs_bnds)
 end
 
-########### The following routines should be templates for all SSAs ###########
-
-# condition for jump to occur
-@inline function (p::RSSACRJumpAggregation)(u, t, integrator)
-    p.next_jump_time == t
-end
-
-# executing jump at the next jump time
-function (p::RSSACRJumpAggregation)(integrator)
-    execute_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
-    generate_jumps!(p, integrator.u, integrator.p, integrator.t)
-    register_next_jump_time!(integrator, p, integrator.t)
-    nothing
-end
-
-# setting up a new simulation
-function (p::RSSACRJumpAggregation)(dj, u, t, integrator) # initialize
-    initialize!(p, integrator, u, integrator.p, t)
-    register_next_jump_time!(integrator, p, t)
-    nothing
-end
-
 ############################# Required Functions ##############################
 
 # creating the JumpAggregation structure (function wrapper-based constant jumps)

--- a/src/aggregators/sortingdirect.jl
+++ b/src/aggregators/sortingdirect.jl
@@ -4,6 +4,7 @@
 
 mutable struct SortingDirectJumpAggregation{T,S,F1,F2,RNG,DEPGR} <: AbstractSSAJumpAggregator
     next_jump::Int
+    prev_jump::Int
     next_jump_time::T
     end_time::T
     cur_rates::Vector{T}
@@ -38,7 +39,7 @@ function SortingDirectJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr
 
     # map jump idx to idx in cur_rates
     jtoidx = collect(1:length(crs))
-    SortingDirectJumpAggregation{T,S,F1,F2,RNG,typeof(dg)}(nj, njt, et, crs, sr,
+    SortingDirectJumpAggregation{T,S,F1,F2,RNG,typeof(dg)}(nj, nj, njt, et, crs, sr,
                                 maj, rs, affs!, sps, rng, dg, jtoidx, zero(Int))
 end
 

--- a/src/aggregators/sortingdirect.jl
+++ b/src/aggregators/sortingdirect.jl
@@ -42,29 +42,6 @@ function SortingDirectJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr
                                 maj, rs, affs!, sps, rng, dg, jtoidx, zero(Int))
 end
 
-
-########### The following routines should be templates for all SSAs ###########
-
-# condition for jump to occur
-@inline function (p::SortingDirectJumpAggregation)(u, t, integrator)
-    p.next_jump_time == t
-end
-
-# executing jump at the next jump time
-function (p::SortingDirectJumpAggregation)(integrator)
-    execute_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
-    generate_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
-    register_next_jump_time!(integrator, p, integrator.t)
-    nothing
-end
-
-# setting up a new simulation
-function (p::SortingDirectJumpAggregation)(dj, u, t, integrator) # initialize
-    initialize!(p, integrator, u, integrator.p, t)
-    register_next_jump_time!(integrator, p, t)
-    nothing
-end
-
 ############################# Required Functions ##############################
 
 # creating the JumpAggregation structure (function wrapper-based constant jumps)

--- a/src/aggregators/ssajump.jl
+++ b/src/aggregators/ssajump.jl
@@ -3,7 +3,7 @@ An aggregator interface for SSA-like algorithms.
 
 ### Required Fields
 - `next_jump`          # the next jump to execute
-- `last_jump`          # the previous jump that was executed
+- `prev_jump`          # the previous jump that was executed
 - `next_jump_time`     # the time of the next jump
 - `end_time`           # the time to stop a simulation
 - `cur_rates`          # vector of current propensity values
@@ -176,6 +176,9 @@ Execute `p.next_jump`.
         idx = next_jump - num_ma_rates
         @inbounds p.affects![idx](integrator)
     end
+
+    # save jump that was just exectued 
+    p.prev_jump = next_jump
     return integrator.u
 end
 

--- a/src/aggregators/ssajump.jl
+++ b/src/aggregators/ssajump.jl
@@ -2,45 +2,62 @@
 An aggregator interface for SSA-like algorithms.
 
 ### Required Fields
-- `next_jump`
-- `next_jump_time`
-- `end_time`
-- `cur_rates`
-- `sum_rate`
-- `ma_jumps`
-- `rates`
-- `affects!`
-- `save_positions`
-- `rng`
+- `next_jump`          # the next jump to execute
+- `last_jump`          # the previous jump that was executed
+- `next_jump_time`     # the time of the next jump
+- `end_time`           # the time to stop a simulation
+- `cur_rates`          # vector of current propensity values
+- `sum_rate`           # sum of current propensity values
+- `ma_jumps`           # any MassActionJumps for the system (scalar form)
+- `rates`              # vector of rate functions for ConstantRateJumps
+- `affects!`           # vector of affect functions for ConstantRateJumps
+- `save_positions`     # tuple for whether to save the jumps before and/or after event
+- `rng`                # random number generator
+
+### Optional fields:
+- `dep_gr`             # dependency graph, dep_gr[i] = indices of reactions that should
+                       # be updated when rx i occurs.    
 """
 abstract type AbstractSSAJumpAggregator <: AbstractJumpAggregator end
 
 DiscreteCallback(c::AbstractSSAJumpAggregator) = DiscreteCallback(c, c, initialize = c, save_positions = c.save_positions)
 
-########### The following routines should be templates for all SSAs ###########
+########### The following routines are templates for all SSAs ###########
+########### Generally they should not need to be overloaded.  ###########
 
-# # condition for jump to occur
-# @inline function (p::SSAJumpAggregator)(u, t, integrator)
-#   p.next_jump_time == t
-# end
+## Users will normally define (see direct.jl for examples):
+# aggregate
+# initialize!
+# execute_jumps!
+# generate_jumps!
 
-# # executing jump at the next jump time
-# function (p::SSAJumpAggregator)(integrator)
-#   execute_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
-#   generate_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
-#   register_next_jump_time!(integrator, p, integrator.t)
-#   nothing
-# end
+# condition for jump to occur
+@inline function (p::AbstractSSAJumpAggregator)(u, t, integrator)
+  p.next_jump_time == t
+end
 
-# # setting up a new simulation
-# function (p::SSAJumpAggregator)(dj, u, t, integrator) # initialize
-#   initialize!(p, integrator, u, integrator.p, t)
-#   register_next_jump_time!(integrator, p, integrator.t)
-#   nothing
-# end
+# executing jump at the next jump time
+function (p::AbstractSSAJumpAggregator)(integrator)
+  execute_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
+  generate_jumps!(p, integrator, integrator.u, integrator.p, integrator.t)
+  register_next_jump_time!(integrator, p, integrator.t)
+  nothing
+end
+
+# setting up a new simulation
+function (p::AbstractSSAJumpAggregator)(dj, u, t, integrator) # initialize
+  initialize!(p, integrator, u, integrator.p, t)
+  register_next_jump_time!(integrator, p, integrator.t)
+  nothing
+end
 
 ############################## Generic Routines ###############################
 
+"""
+    register_next_jump_time!(integrator, p::AbstractSSAJumpAggregator, t)
+
+Adds a `tstop` to the integrator at the next jump time.
+"""
 @inline function register_next_jump_time!(integrator, p::AbstractSSAJumpAggregator, t)
     if p.next_jump_time < p.end_time
         add_tstop!(integrator, p.next_jump_time)
@@ -48,7 +65,12 @@ DiscreteCallback(c::AbstractSSAJumpAggregator) = DiscreteCallback(c, c, initiali
     nothing
 end
 
-# helper routine for setting up standard fields of SSA jump aggregations
+"""
+    build_jump_aggregation(jump_agg_type, u, p, t, end_time, ma_jumps, rates,
+                           affects!, save_positions, rng; kwargs...)
+
+Helper routine for setting up standard fields of SSA jump aggregations.
+"""
 function build_jump_aggregation(jump_agg_type, u, p, t, end_time, ma_jumps, rates,
                                 affects!, save_positions, rng; kwargs...)
 
@@ -70,7 +92,11 @@ function build_jump_aggregation(jump_agg_type, u, p, t, end_time, ma_jumps, rate
                 majumps, rates, affects!, save_positions, rng; kwargs...)
 end
 
-# reevaluate all rates and total rate
+"""
+    fill_rates_and_sum!(p::AbstractSSAJumpAggregator, u, params, t)
+
+Reevaluate all rates and their sum.
+"""
 function fill_rates_and_sum!(p::AbstractSSAJumpAggregator, u, params, t)
     sum_rate = zero(typeof(p.sum_rate))
 
@@ -95,8 +121,29 @@ function fill_rates_and_sum!(p::AbstractSSAJumpAggregator, u, params, t)
     nothing
 end
 
-# recalculate jump rates for jumps that depend on the just executed jump
-# requires dependency graph
+
+"""
+    calculate_jump_rate(ma_jumps, rates, u, params, t, rx)
+
+Recalculate the rate for the jump with index `rx`.
+"""
+@inline function calculate_jump_rate(ma_jumps, rates, u, params, t, rx)
+    num_majumps = get_num_majumps(ma_jumps)
+    if rx <= num_majumps
+        return evalrxrate(u, rx, ma_jumps)
+    else
+        @inbounds return rates[rx - num_majumps](u, params, t)
+    end
+end
+
+"""
+    update_dependent_rates!(p::AbstractSSAJumpAggregator, u, params, t)
+
+Recalculate jump rates for jumps that depend on the just executed jump. 
+
+Notes: 
+    - Intended for methods that have a dependency graph, i.e. define `p.dep_gr`.
+"""
 function update_dependent_rates!(p::AbstractSSAJumpAggregator, u, params, t)
     @inbounds dep_rxs = p.dep_gr[p.next_jump]
     cur_rates   = p.cur_rates
@@ -111,7 +158,11 @@ function update_dependent_rates!(p::AbstractSSAJumpAggregator, u, params, t)
     nothing
 end
 
-# Update state based on the p.next_jump
+"""
+    update_state!(p::AbstractSSAJumpAggregator, integrator, u)
+
+Execute `p.next_jump`.
+"""
 @inline function update_state!(p::AbstractSSAJumpAggregator, integrator, u)
     @unpack ma_jumps, next_jump = p
     num_ma_rates = get_num_majumps(ma_jumps)
@@ -128,17 +179,26 @@ end
     return integrator.u
 end
 
-"check if the total rate is 0 and if it is, make the next jump time Inf"
+"""
+    nomorejumps!(p, sum_rate) :: Bool
+
+Check if the total rate is zero, and if it is, make the next jump time Inf.
+"""
 @inline function nomorejumps!(p, sum_rate) :: Bool
     if sum_rate < eps(typeof(sum_rate))
-        p.next_jump = 0
+        p.next_jump      = zero(p.next_jump)
         p.next_jump_time = convert(typeof(sum_rate), Inf)
         return true
     end
     return false
 end
 
-"perform linear search of r over array. Output element j s.t. array[j-1] < r <= array[j]. Will error if no such r exists"
+"""
+    linear_search(array, r)
+
+Perform linear search for `r` over array of increasing elements. Output element
+j s.t. array[j-1] < r <= array[j]. Will error if no such r exists
+"""
 @inline function linear_search(array, r)
     jidx = 1
     @inbounds parsum = array[jidx]
@@ -149,7 +209,11 @@ end
     return jidx
 end
 
-"perform rejection sampling test"
+"""
+    rejectrx(ma_jumps, rates, cur_rate_high, cur_rate_low, rng, u, jidx, params, t)
+
+Perform rejection sampling test (used in RSSA methods).
+"""
 @inline function rejectrx(ma_jumps, rates, cur_rate_high, cur_rate_low, rng, u, jidx, params, t)
     # rejection test
     @inbounds r2     = rand(rng) * cur_rate_high[jidx]
@@ -165,14 +229,4 @@ end
         end
     end
     return true
-end
-
-"update the jump rate, assuming p.rates is a vector of functions"
-@inline function calculate_jump_rate(ma_jumps, rates, u, params, t, rx)
-    num_majumps = get_num_majumps(ma_jumps)
-    if rx <= num_majumps
-        return evalrxrate(u, rx, ma_jumps)
-    else
-        @inbounds return rates[rx - num_majumps](u, params, t)
-    end
 end

--- a/test/bimolerx_test.jl
+++ b/test/bimolerx_test.jl
@@ -67,9 +67,9 @@ prob = DiscreteProblem(u0, (0.0, tf), rates)
 # plotting one full trajectory
 if doplot
     for alg in SSAalgs
-        jump_prob = JumpProblem(prob, alg, majumps, vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
-        sol = solve(jump_prob, SSAStepper())
-        plothand = plot(sol, seriestype=:steppost, reuse=false)
+        local jump_prob = JumpProblem(prob, alg, majumps, vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
+        local sol = solve(jump_prob, SSAStepper())
+        local plothand = plot(sol, seriestype=:steppost, reuse=false)
         display(plothand)
     end
 end
@@ -78,7 +78,7 @@ end
 if dotestmean
     means = zeros(Float64,length(SSAalgs))
     for (i,alg) in enumerate(SSAalgs)
-        jump_prob = JumpProblem(prob, alg, majumps, save_positions=(false,false), vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
+        local jump_prob = JumpProblem(prob, alg, majumps, save_positions=(false,false), vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
         means[i]  = runSSAs(jump_prob)
         relerr = abs(means[i] - expected_avg) / expected_avg
         if doprintmeans

--- a/test/constant_rate.jl
+++ b/test/constant_rate.jl
@@ -30,8 +30,8 @@ sol = solve(jump_prob,FunctionMap())
 
 nums = Int[]
 @time for i in 1:10000
-  jump_prob = JumpProblem(prob,Direct(),jump,jump2)
-  sol = solve(jump_prob,FunctionMap())
+  local jump_prob = JumpProblem(prob,Direct(),jump,jump2)
+  local sol = solve(jump_prob,FunctionMap())
   push!(nums,sol[end])
 end
 
@@ -45,8 +45,8 @@ sol = solve(jump_prob,FunctionMap())
 
 nums = Int[]
 @time for i in 1:10000
-  jump_prob = JumpProblem(prob,Direct(),jump,jump2)
-  sol = solve(jump_prob,FunctionMap())
+  local jump_prob = JumpProblem(prob,Direct(),jump,jump2)
+  local sol = solve(jump_prob,FunctionMap())
   push!(nums,sol[2])
 end
 

--- a/test/degenerate_rx_cases.jl
+++ b/test/degenerate_rx_cases.jl
@@ -99,8 +99,8 @@ jump_to_dep_specs = [[1],[1]]
 namedpars = (dep_graph=dep_graph, vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
 
 for method in methods
-    jump_prob = JumpProblem(prob, method, jump, jump2; namedpars...)
-    sol = solve(jump_prob, SSAStepper())
+    local jump_prob = JumpProblem(prob, method, jump, jump2; namedpars...)
+    local sol = solve(jump_prob, SSAStepper())
 
     if doplot
         plot!(plothand2, sol, label=("A <-> 0, " * string(method)))

--- a/test/extinction_test.jl
+++ b/test/extinction_test.jl
@@ -20,7 +20,7 @@ algs = DiffEqJump.JUMP_AGGREGATORS
 
 for ssa in algs
     jprob = JumpProblem(dprob, ssa, majump; vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs, save_positions=(false,false))
-    sol = solve(jprob, SSAStepper(), saveat=100.)
+    local sol = solve(jprob, SSAStepper(), saveat=100.)
     @test sol[1,end] == 0
     @test sol.t[end] < Inf
 end
@@ -30,7 +30,7 @@ dprob = DiscreteProblem(u0,(0.,100.),rates)
 
 for ssa in algs
     jprob = JumpProblem(dprob, ssa, majump; vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs, save_positions=(false,false))
-    sol = solve(jprob, SSAStepper(), saveat=100.)
+    local sol = solve(jprob, SSAStepper(), saveat=100.)
     @test sol[1,end] == 0
     @test sol.t[end] < Inf
 end

--- a/test/geneexpr_test.jl
+++ b/test/geneexpr_test.jl
@@ -73,8 +73,8 @@ prob = DiscreteProblem(u0, (0.0, tf), rates)
 if doplot
     plothand = plot(reuse=false)
     for alg in SSAalgs
-        jump_prob = JumpProblem(prob, alg, majumps, vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
-        sol = solve(jump_prob, SSAStepper())
+        local jump_prob = JumpProblem(prob, alg, majumps, vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
+        local sol = solve(jump_prob, SSAStepper())
         plot!(plothand, sol.t, sol[3,:], seriestype=:steppost)
     end
     display(plothand)
@@ -84,7 +84,7 @@ end
 if dotestmean
     means = zeros(Float64,length(SSAalgs))
     for (i,alg) in enumerate(SSAalgs)
-        jump_prob = JumpProblem(prob, alg, majumps, save_positions=(false,false), vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
+        local jump_prob = JumpProblem(prob, alg, majumps, save_positions=(false,false), vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs)
         means[i]  = runSSAs(jump_prob)
         relerr = abs(means[i] - expected_avg) / expected_avg
         if doprintmeans

--- a/test/linearreaction_test.jl
+++ b/test/linearreaction_test.jl
@@ -287,7 +287,7 @@ end
 
 for method in SSAalgs
     for jump_prob_gen in jump_prob_gens
-        jump_prob = jump_prob_gen(Nrxs, method)
+        local jump_prob = jump_prob_gen(Nrxs, method)
         meanval   = runSSAs(jump_prob)
         if doprint
             println("Method: ", method, ", Jump input types: ", jump_prob_gen,
@@ -306,7 +306,7 @@ SSAalgs        = [RDirect(), NRM(), SortingDirect(), DirectCR()]
 jump_prob_gens = [A_to_B_ma]
 for method in SSAalgs
     for jump_prob_gen in jump_prob_gens
-        jump_prob = jump_prob_gen(Nrxs, method)
+        local jump_prob = jump_prob_gen(Nrxs, method)
         meanval   = runSSAs(jump_prob)
         if doprint
             println("Method: ", method, ", Jump input types: ", jump_prob_gen,

--- a/test/monte_carlo_test.jl
+++ b/test/monte_carlo_test.jl
@@ -8,13 +8,13 @@ affect! = integrator -> (integrator.u[1] = integrator.u[1]/2)
 jump = VariableRateJump(rate, affect!, save_positions=(false,true))
 jump_prob = JumpProblem(prob,Direct(),jump)
 monte_prob = EnsembleProblem(jump_prob)
-sol = solve(monte_prob,SRIW1(),trajectories=3,parallel_type=:none,
+sol = solve(monte_prob,SRIW1(),EnsembleSerial(), trajectories=3,
             save_everystep=false,dt=0.001,adaptive=false)
 @test sol[1].t[2] != sol[2].t[2] != sol[3].t[2]
 
 jump = ConstantRateJump(rate, affect!)
 jump_prob = JumpProblem(prob,Direct(),jump,save_positions=(true,false))
 monte_prob = EnsembleProblem(jump_prob)
-sol = solve(monte_prob,SRIW1(),trajectories=3,parallel_type=:none,
+sol = solve(monte_prob,SRIW1(),EnsembleSerial(),trajectories=3,
             save_everystep=false,dt=0.001,adaptive=false)
 @test sol[1].t[2] != sol[2].t[2] != sol[3].t[2]

--- a/test/splitcoupled.jl
+++ b/test/splitcoupled.jl
@@ -92,7 +92,7 @@ Nsims = 8000
 Amean = 0.
 for i in 1:Nsims
   global Amean
-  sol    = solve(jump_prob,Tsit5(),saveat=10.)
+  local sol = solve(jump_prob,Tsit5(),saveat=10.)
   Amean += sol[1,end]
 end
 Amean /= Nsims


### PR DESCRIPTION
1. Further @Vilin97's work extracting out common functionality by factoring out the functors for aggregations.
2. Comment the utility SSA routines.
3. Add a field `prev_jump` to all aggregations to address https://github.com/SciML/DiffEqJump.jl/issues/132
4. Fix 1.5 scope warnings in the tests.