### PR TITLE
Crashing extinction test

### DIFF
--- a/src/aggregators/directcr.jl
+++ b/src/aggregators/directcr.jl
@@ -109,9 +109,11 @@ end
 
 # calculate the next jump / jump time
 function generate_jumps!(p::DirectCRJumpAggregation, integrator, u, params, t)
-    p.next_jump       = sample(p.rt, p.cur_rates, p.rng)
     p.next_jump_time  = t + randexp(p.rng) / p.sum_rate
-    #@assert !(iszero(p.next_jump) && (t <= p.end_time)) "Error, no jump was sampled but the next jump time is smaller than the end_time, idx=$(p.next_jump), time=$(p.next_jump_time), end_time=$(p.end_time), sum_rate=$(p.sum_rate)."
+    
+    if p.next_jump_time < p.end_time
+        p.next_jump = sample(p.rt, p.cur_rates, p.rng)
+    end    
     nothing
 end
 

--- a/src/aggregators/directcr.jl
+++ b/src/aggregators/directcr.jl
@@ -109,23 +109,14 @@ end
 
 # calculate the next jump / jump time
 function generate_jumps!(p::DirectCRJumpAggregation, integrator, u, params, t)
-    @fastmath p.next_jump_time = t + calc_next_jump!(p, u, params, t)
+    p.next_jump       = sample(p.rt, p.cur_rates, p.rng)
+    p.next_jump_time  = t + randexp(p.rng) / p.sum_rate
+    #@assert !(iszero(p.next_jump) && (t <= p.end_time)) "Error, no jump was sampled but the next jump time is smaller than the end_time, idx=$(p.next_jump), time=$(p.next_jump_time), end_time=$(p.end_time), sum_rate=$(p.sum_rate)."
     nothing
 end
 
 
 ######################## SSA specific helper routines #########################
-
-# searches down the rate list for the next reaction
-@fastmath function calc_next_jump!(p::DirectCRJumpAggregation, u, params, t)
-
-    # next jump type
-    p.next_jump = sample(p.rt, p.cur_rates, p.rng)
-
-    # return time to next jump
-    randexp(p.rng) / p.sum_rate
-end
-
 
 # recalculate jump rates for jumps that depend on the just executed jump
 # requires dependency graph
@@ -138,15 +129,10 @@ function update_dependent_rates!(p::DirectCRJumpAggregation, u, params, t)
         oldrate = cur_rates[rx]
 
         # update rate
-        if rx <= num_majumps
-            newrate = evalrxrate(u, rx, ma_jumps)
-        else
-            newrate = rates[rx-num_majumps](u, params, t)
-        end
-        cur_rates[rx] = newrate
+        cur_rates[rx] = calculate_jump_rate(ma_jumps, num_majumps, rates, u, params, t, rx)
 
         # update table
-        update!(rt, rx, oldrate, newrate)
+        update!(rt, rx, oldrate, cur_rates[rx])
     end
 
     p.sum_rate = groupsum(rt)

--- a/src/aggregators/nrm.jl
+++ b/src/aggregators/nrm.jl
@@ -84,12 +84,13 @@ end
 function update_dependent_rates!(p::NRMJumpAggregation, u, params, t)
     @inbounds dep_rxs = p.dep_gr[p.next_jump]
     @unpack cur_rates, rates, ma_jumps = p
+    num_majumps = get_num_majumps(ma_jumps)
     
     @inbounds for rx in dep_rxs
         oldrate = cur_rates[rx]
 
         # update the jump rate
-        @inbounds cur_rates[rx] = calculate_jump_rate(ma_jumps, rates, u, params, t, rx)
+        @inbounds cur_rates[rx] = calculate_jump_rate(ma_jumps, num_majumps, rates, u, params, t, rx)
 
         # calculate new jump times for dependent jumps
         if rx != p.next_jump && oldrate > zero(oldrate)

--- a/src/aggregators/prioritytable.jl
+++ b/src/aggregators/prioritytable.jl
@@ -286,6 +286,7 @@ function sample(pt::PriorityTable, priorities, rng=Random.GLOBAL_RNG)
     @inbounds r = rand(rng) * gsum - gsums[gid]
     while r > zero(r)
         gid -= one(gid)
+        iszero(gid) && return gid   # if no result found return zero
         @inbounds r -= gsums[gid]
     end
 

--- a/src/aggregators/prioritytable.jl
+++ b/src/aggregators/prioritytable.jl
@@ -282,13 +282,23 @@ function sample(pt::PriorityTable, priorities, rng=Random.GLOBAL_RNG)
 
     # sample a group, search from end (largest priorities)
     # NOTE, THIS ASSUMES THE FIRST PRIORITY IS ZERO!!!
-    gid = length(gsums)
-    @inbounds r = rand(rng) * gsum - gsums[gid]
-    while r > zero(r)
-        gid -= one(gid)
-        iszero(gid) && return gid   # if no result found return zero
-        @inbounds r -= gsums[gid]
+    # gid = length(gsums)
+    # @inbounds r = rand(rng) * gsum - gsums[gid]
+    # while r > zero(r)
+    #     gid -= one(gid)
+    #     iszero(gid) && return gid   # if no result found return zero
+    #     @inbounds r -= gsums[gid]
+    # end
+    gid = 0
+    r   = rand(rng) * gsum
+    @inbounds for i = length(gsums):-1:1
+        r -= gsums[i]
+        if r <= zero(r)
+            gid = i
+            break
+        end        
     end
+    iszero(gid) && return gid
 
     # sample element within the group
     @inbounds sample(groups[gid], priorities, rng)

--- a/src/aggregators/rdirect.jl
+++ b/src/aggregators/rdirect.jl
@@ -100,9 +100,10 @@ end
 function update_dependent_rates!(p::RDirectJumpAggregation, u, params, t)
     @inbounds dep_rxs = p.dep_gr[p.next_jump]
     @unpack ma_jumps, rates, cur_rates, sum_rate = p
+    num_majumps = get_num_majumps(ma_jumps)
     max_rate_increased = false
     @inbounds for rx in dep_rxs
-        @inbounds new_rate = calculate_jump_rate(ma_jumps, rates, u,params,t,rx)
+        @inbounds new_rate = calculate_jump_rate(ma_jumps, num_majumps, rates, u,params,t,rx)
         sum_rate += new_rate - cur_rates[rx]
         if new_rate > p.max_rate
             p.max_rate = new_rate

--- a/src/aggregators/rssa.jl
+++ b/src/aggregators/rssa.jl
@@ -98,7 +98,7 @@ function execute_jumps!(p::RSSAJumpAggregation, integrator, u, params, t)
 end
 
 # calculate the next jump / jump time
-@fastmath function generate_jumps!(p::RSSAJumpAggregation, integrator, u, params, t)
+function generate_jumps!(p::RSSAJumpAggregation, integrator, u, params, t)
     sum_rate = p.sum_rate
     # if no more events possible there is nothing to do
     if nomorejumps!(p, sum_rate)

--- a/src/aggregators/rssa.jl
+++ b/src/aggregators/rssa.jl
@@ -106,13 +106,16 @@ end
     end
     # next jump type
     @unpack ma_jumps, rates, cur_rate_high, cur_rate_low, rng = p
+    num_majumps = get_num_majumps(ma_jumps)
     #rerl        = one(sum_rate)
     rerl        = zero(sum_rate)
 
     r      = rand(rng) * sum_rate
     jidx   = linear_search(cur_rate_high, r)
     rerl  += randexp(rng)
-    @inbounds while rejectrx(ma_jumps, rates, cur_rate_high, cur_rate_low, rng, u, jidx, params, t)
+    @inbounds while (jidx > zero(jidx)) && rejectrx(ma_jumps, num_majumps, rates, 
+                                                    cur_rate_high, cur_rate_low, 
+                                                    rng, u, jidx, params, t)
         # sample candidate reaction
         r      = rand(rng) * sum_rate
         jidx   = linear_search(cur_rate_high, r)
@@ -123,6 +126,7 @@ end
 
     #p.next_jump_time = t + (-one(sum_rate) / sum_rate) * log(rerl)
     p.next_jump_time = t + rerl / sum_rate
+    #@assert !(iszero(jidx) && (p.next_jump_time <= p.end_time)) "Error, no jump was sampled but the next jump time is smaller than the end_time, idx=$jidx, time=$(p.next_jump_time), end_time=$(p.end_time)."
 
     nothing
 end

--- a/src/aggregators/rssacr.jl
+++ b/src/aggregators/rssacr.jl
@@ -148,7 +148,6 @@ function generate_jumps!(p::RSSACRJumpAggregation, integrator, u, params, t)
 
     # update time to next jump
     p.next_jump_time = t + rerl / sum_rate
-
     nothing
 end
 

--- a/src/aggregators/rssacr.jl
+++ b/src/aggregators/rssacr.jl
@@ -147,8 +147,7 @@ function generate_jumps!(p::RSSACRJumpAggregation, integrator, u, params, t)
     p.next_jump = jidx
 
     # update time to next jump
-    # if jidx = 0 we force the simulation to end
-    p.next_jump_time = iszero(jidx) ? Inf : (t + rerl / sum_rate)
+    p.next_jump_time = t + rerl / sum_rate
 
     nothing
 end

--- a/src/aggregators/sortingdirect.jl
+++ b/src/aggregators/sortingdirect.jl
@@ -84,7 +84,7 @@ end
 
 # calculate the next jump / jump time
 function generate_jumps!(p::SortingDirectJumpAggregation, integrator, u, params, t)
-    @fastmath p.next_jump_time = t + randexp(p.rng) / p.sum_rate
+    p.next_jump_time = t + randexp(p.rng) / p.sum_rate
 
     # search for next jump
     if p.next_jump_time < p.end_time            

--- a/src/aggregators/ssajump.jl
+++ b/src/aggregators/ssajump.jl
@@ -149,9 +149,9 @@ function update_dependent_rates!(p::AbstractSSAJumpAggregator, u, params, t)
     sum_rate    = p.sum_rate
     num_majumps = get_num_majumps(p.ma_jumps)
     @inbounds for rx in dep_rxs
-        oldrate = cur_rates[rx]
+        sum_rate -= cur_rates[rx]
         @inbounds cur_rates[rx] = calculate_jump_rate(p.ma_jumps, num_majumps, p.rates, u,params,t,rx)
-        sum_rate += cur_rates[rx] - oldrate
+        sum_rate += cur_rates[rx]
     end
 
     p.sum_rate = sum_rate
@@ -203,7 +203,7 @@ Perform linear search for `r` over array. Output index j s.t. sum(array[1:j-1])
 < r <= sum(array[1:j]).
 
 Notes:
-- Returns index one if the search is unsuccessful. Assumes this corresponds to
+- Returns index zero if the search is unsuccessful. Assumes this corresponds to
   the case of an infinite next reaction time and so the jump index does not
   matter.
 """
@@ -217,11 +217,7 @@ Notes:
             break
         end
     end
-    # while parsum < r
-    #     jidx   += 1
-    #     @assert jidx <= length(array) "$parsum, $r, $jidx, $(length(array)), $(sum(array))"
-    #     @inbounds parsum += array[jidx]        
-    # end
+
     return jidx
 end
 

--- a/test/extinction_test.jl
+++ b/test/extinction_test.jl
@@ -9,27 +9,28 @@ netstoch = [
     [1 => -1]
 ]
 
+Nsims = 10
 rates = [1.]
-spec_to_dep_jumps = [[1]]
-jump_to_dep_specs = [[1]]
 dg = [[1]]
 majump = MassActionJump(rates, reactstoch, netstoch)
-u0 = [10]
-dprob = DiscreteProblem(u0,(0.,100.),rates)
+u0 = [100000]
+dprob = DiscreteProblem(u0,(0.,1e5),rates)
 algs = DiffEqJump.JUMP_AGGREGATORS
 
-for ssa in algs
-    local jprob = JumpProblem(dprob, ssa, majump; vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs, save_positions=(false,false))
-    local sol = solve(jprob, SSAStepper(), saveat=100.)
-    @test sol[1,end] == 0
-    @test sol.t[end] < Inf
+for n = 1:Nsims
+    for ssa in algs
+        local jprob = JumpProblem(dprob, ssa, majump, save_positions=(false,false))
+        local sol = solve(jprob, SSAStepper())
+        @test sol[1,end] == 0
+        @test sol.t[end] < Inf
+    end
 end
 
 u0 = SA[10]
 dprob = DiscreteProblem(u0,(0.,100.),rates)
 
 for ssa in algs
-    local jprob = JumpProblem(dprob, ssa, majump; vartojumps_map=spec_to_dep_jumps, jumptovars_map=jump_to_dep_specs, save_positions=(false,false))
+    local jprob = JumpProblem(dprob, ssa, majump, save_positions=(false,false))
     local sol = solve(jprob, SSAStepper(), saveat=100.)
     @test sol[1,end] == 0
     @test sol.t[end] < Inf

--- a/test/linearreaction_test.jl
+++ b/test/linearreaction_test.jl
@@ -312,6 +312,7 @@ for method in SSAalgs
             println("Method: ", method, ", Jump input types: ", jump_prob_gen,
                     ", sample mean = ", meanval, ", actual mean = ", exactmeanval)
         end
+        @show method
         @test abs(meanval - exactmeanval) < 1.
 
         # if dobenchmark

--- a/test/linearreaction_test.jl
+++ b/test/linearreaction_test.jl
@@ -312,7 +312,6 @@ for method in SSAalgs
             println("Method: ", method, ", Jump input types: ", jump_prob_gen,
                     ", sample mean = ", meanval, ", actual mean = ", exactmeanval)
         end
-        @show method
         @test abs(meanval - exactmeanval) < 1.
 
         # if dobenchmark

--- a/test/reversible_binding.jl
+++ b/test/reversible_binding.jl
@@ -40,7 +40,7 @@ analytic_mean = analyticmean(u0, K)
 algs = DiffEqJump.JUMP_AGGREGATORS
 relative_tolerance = 0.01
 for alg in algs
-    jprob = JumpProblem(prob,alg,majumps,save_positions=(false,false))
-    Amean = getmean(jprob, Nsims)
+    local jprob = JumpProblem(prob,alg,majumps,save_positions=(false,false))
+    local Amean = getmean(jprob, Nsims)
     @test abs(Amean - analytic_mean)/analytic_mean < relative_tolerance
 end


### PR DESCRIPTION
This seems to fix https://github.com/SciML/DiffEqJump.jl/issues/148.

Note, to try to minimize extra branches in hot loops this assumes that for 
1. SortingDirect and DirectCR the issue can be detected by simply checking if the next reaction time is greater than the simulation end time before calculating the next jump (and in that case the next jump is not calculated).
2. RSSA and RSSACR that if this issue crops up it will appear in the first search for the next reaction, so a check is only needed after it. There I now explicitly set the next reaction time to `Inf` if the search failed and return. (But perhaps we should instead recalculate the sum in this case to make sure there are not other issues, and if it isn't zero try sampling again?)

@Vilin97 mind taking a look? Any thoughts?

I also added some more refactoring I noticed while working on this.