### PR TITLE
Enable DataStructures 0.18

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 [compat]
 ArrayInterface = "2.8"
 Compat = "2.2, 3.0"
-DataStructures = "0.17"
+DataStructures = "0.17, 0.18"
 DiffEqBase = "6.11"
 FunctionWrappers = "1.0"
 PoissonRandom = "0.4"

--- a/src/DiffEqJump.jl
+++ b/src/DiffEqJump.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module DiffEqJump
 
 using DiffEqBase, Compat, RandomNumbers, TreeViews, LinearAlgebra
@@ -8,7 +6,7 @@ using FunctionWrappers, UnPack
 
 import DiffEqBase: DiscreteCallback, init, solve, solve!, plot_indices
 import Base: size, getindex, setindex!, length, similar, show
-import DataStructures: length, update!
+import DataStructures: update!
 
 import RecursiveArrayTools: recursivecopy!
 using StaticArrays, Base.Threads


### PR DESCRIPTION
I didn't spot any occurrences of `top`, so it seems to be fine. As for basically all other tests will fail since (test) dependencies do not support DataStructures 0.18 yet. DiffEqJump prevents me from testing OrdinaryDiffEq though, so I guess it would be good to release a new version. If we later figure out that something is broken, we could always make a new bugfix release.