### PR TITLE
Make dependency graphs more flexible

### DIFF
--- a/src/aggregators/directcr.jl
+++ b/src/aggregators/directcr.jl
@@ -44,10 +44,10 @@ function DirectCRJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
         end
     else
         dg = dep_graph
-    end
 
-    # make sure each jump depends on itself
-    add_self_dependencies!(dg)
+        # make sure each jump depends on itself
+        add_self_dependencies!(dg)
+    end
 
     # mapping from jump rate to group id
     minexponent = exponent(minrate)

--- a/src/aggregators/nrm.jl
+++ b/src/aggregators/nrm.jl
@@ -30,10 +30,10 @@ function NRMJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
         end
     else
         dg = dep_graph
-    end
 
-    # make sure each jump depends on itself
-    add_self_dependencies!(dg)
+        # make sure each jump depends on itself
+        add_self_dependencies!(dg)
+    end
 
     pq = MutableBinaryMinHeap{T}()
 

--- a/src/aggregators/rdirect.jl
+++ b/src/aggregators/rdirect.jl
@@ -32,10 +32,11 @@ function RDirectJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T, m
         end
     else
         dg = dep_graph
+
+        # make sure each jump depends on itself
+        add_self_dependencies!(dg)
     end
 
-    # make sure each jump depends on itself
-    add_self_dependencies!(dg)
     max_rate = maximum(crs)
     return RDirectJumpAggregation{T,S,F1,F2,RNG,typeof(dg)}(nj, nj, njt, et, crs, sr, maj, rs, affs!, sps, rng,
         dg, max_rate, 0, counter_threshold)

--- a/src/aggregators/sortingdirect.jl
+++ b/src/aggregators/sortingdirect.jl
@@ -32,10 +32,10 @@ function SortingDirectJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr
         end
     else
         dg = dep_graph
-    end
 
-    # make sure each jump depends on itself
-    add_self_dependencies!(dg)
+        # make sure each jump depends on itself
+        add_self_dependencies!(dg)
+    end
 
     # map jump idx to idx in cur_rates
     jtoidx = collect(1:length(crs))

--- a/src/aggregators/ssajump.jl
+++ b/src/aggregators/ssajump.jl
@@ -74,7 +74,7 @@ Helper routine for setting up standard fields of SSA jump aggregations.
 function build_jump_aggregation(jump_agg_type, u, p, t, end_time, ma_jumps, rates,
                                 affects!, save_positions, rng; kwargs...)
 
-  # mass action jumps
+    # mass action jumps
     majumps = ma_jumps
     if majumps === nothing
         majumps = MassActionJump(Vector{typeof(t)}(),
@@ -82,7 +82,7 @@ function build_jump_aggregation(jump_agg_type, u, p, t, end_time, ma_jumps, rate
                              Vector{Vector{Pair{Int,eltype(u)}}}())
     end
 
-  # current jump rates, allows mass action rates and constant jumps
+    # current jump rates, allows mass action rates and constant jumps
     cur_rates = Vector{typeof(t)}(undef, get_num_majumps(majumps) + length(rates))
 
     sum_rate = zero(typeof(t))


### PR DESCRIPTION
This converts dependency graph generation to only use vectors. Since the typical case where we'd expect the construction of such graphs to be slow is very large systems, which are usually sparse, this should perform better (and in benchmarking it is 2.5 to 6 times faster for spatial systems with similar reductions in memory use).

This also gives a template for how the MT dependency graph code should be updated for JumpSystems.