### PR TITLE
SSAIntegrator callback test

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using DiffEqJump, DiffEqBase, Test
   @time @testset "Split Coupled Tests" begin include("splitcoupled.jl") end
   @time @testset "SSA Tests" begin include("ssa_tests.jl") end
   @time @testset "Tau Leaping Tests" begin include("regular_jumps.jl") end
+  @time @testset "Simple SSA Callback Test" begin include("ssa_callback_test.jl") end
   @time @testset "SIR Discrete Callback Test" begin include("sir_model.jl") end
   @time @testset "Linear Reaction SSA Test" begin include("linearreaction_test.jl") end
   @time @testset "Mass Action Jump Tests; Gene Expr Model" begin include("geneexpr_test.jl") end

--- a/test/ssa_callback_test.jl
+++ b/test/ssa_callback_test.jl
@@ -1,0 +1,29 @@
+using DiffEqJump, DiffEqBase
+using Test
+
+rate = (u, p, t) -> u[1]
+affect! = function (integrator)
+    integrator.u[1] -= 1
+    integrator.u[2] += 1
+end
+jump = ConstantRateJump(rate, affect!)
+
+prob = DiscreteProblem([0.0, 0.0], (0.0, 10.0))
+jump_prob = JumpProblem(prob, Direct(), jump)
+
+sol = solve(jump_prob, SSAStepper())
+
+@test sol.t == [0.0, 10.0]
+@test sol.u == [[0.0, 0.0], [0.0, 0.0]]
+
+condition(u,t,integrator) = t == 5
+function fuel_affect!(integrator)
+  integrator.u[1] += 100
+  reset_aggregated_jumps!(integrator)
+end
+cb = DiscreteCallback(condition, fuel_affect!, save_positions=(false, true))
+
+sol = solve(jump_prob, SSAStepper(), callback=cb, tstops=[5])
+
+@test sol.t[1:2] == [0.0, 5.0] # no jumps between t=0 and t=5
+@test sol(5 + 1e-10) == [100, 0] # state just after fueling before any decays can happen


### PR DESCRIPTION
This pull request adds a test to validate the changes made in #161. While writing the test I noticed that there remained some subtle problems in `SSAIntegrator` when the system is "extinct" but there are still tstops to be visited. In that case the integrator previously ignored the tstops. This is wrong since a `DiscreteCallback` can modify `integrator.u` at such a future tstop such that the system is no longer extinct.

~~This PR does slightly change the behaviour of `DiffEqBase.step!` for `SSAIntegrator`. Notably the integrator can no longer make steps after the end of the problem `tspan`. I do not know whether the previous behaviour was more desirable.~~