### PR TITLE
Fix out of bounds error for SSAStepper's DiffEqBase.__init

### DIFF
--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -136,7 +136,7 @@ function DiffEqBase.__init(jump_prob::JumpProblem,
                                sol,1,prob.tspan[1],
                                cb,_saveat,save_everystep,save_end,cur_saveat,
                                opts,tstops,1,false,true)
-    cb.initialize(cb,copy(prob.u0),prob.tspan[1],integrator)
+    cb.initialize(cb,integrator.u,prob.tspan[1],integrator)
     integrator
 end
 
@@ -224,5 +224,4 @@ function DiffEqBase.terminate!(integrator::SSAIntegrator, retcode = :Terminated)
 end
 
 export SSAStepper
-
 

--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -128,15 +128,15 @@ function DiffEqBase.__init(jump_prob::JumpProblem,
      sizehint!(u,numsteps_hint)
      sizehint!(t,numsteps_hint)
    else
-     sizehint!(u,2)
-     sizehint!(t,2)
+     sizehint!(u,save_start+save_end)
+     sizehint!(t,save_start+save_end)
    end
 
     integrator = SSAIntegrator(prob.f,copy(prob.u0),prob.tspan[1],prob.tspan[1],prob.p,
                                sol,1,prob.tspan[1],
                                cb,_saveat,save_everystep,save_end,cur_saveat,
                                opts,tstops,1,false,true)
-    cb.initialize(cb,u[1],prob.tspan[1],integrator)
+    cb.initialize(cb,copy(prob.u0),prob.tspan[1],integrator)
     integrator
 end
 

--- a/test/ssa_tests.jl
+++ b/test/ssa_tests.jl
@@ -20,8 +20,23 @@ integrator = init(jump_prob,SSAStepper())
 step!(integrator)
 integrator.u[1]
 
+# test different saving behaviors
+
 sol = solve(jump_prob,SSAStepper())
+@test sol.t[begin] == 0.0
+@test sol.t[end] == 3.0
+
+sol = solve(jump_prob, SSAStepper(),save_end=false)
+@test sol.t[begin] == 0.0
+@test sol.t[end] < 3.0
+
+sol = solve(jump_prob, SSAStepper(),save_start=false)
+@test sol.t[begin] > 0.0
+@test sol.t[end] == 3.0
 
 jump_prob = JumpProblem(prob,Direct(),jump,jump2,save_positions=(false,false))
+sol = solve(jump_prob, SSAStepper(),save_start=false,save_end=false)
+@test isempty(sol.t) && isempty(sol.u)
+
 sol = solve(jump_prob,SSAStepper(),saveat=0.0:0.1:2.9)
 @test sol.t == collect(0.0:0.1:3.0)


### PR DESCRIPTION
In `SSAStepper`'s `DiffEqBase.__init` function, when the kwarg `save_start=false` a local variable `u` gets initialized as an empty array. Later in that function `u[1]` is accessed leading to an error. This is fixed in this pr.

Additionally make `sizehint!` more accurate in the edge case where `save_everystep==false` and `isempty(saveat)`. This is
particularly helpful in situations where one frequently remakes JumpProblems and has to avoid allocations for every `DiffEqBase.solve` call.

Some tests were added to avoid future regressions.
