### PR TITLE
remake for JumpProblems

### DIFF
--- a/test/remake_test.jl
+++ b/test/remake_test.jl
@@ -21,7 +21,6 @@ tspan = (0.0,2500.0)
 dprob  = DiscreteProblem(u0,tspan,p)
 jprob = JumpProblem(dprob,Direct(),jump,jump2,save_positions=(false,false))
 sol = solve(jprob, SSAStepper())
-
 @test sol[1,end] == 0
 
 u02 = [1000,1,0]

--- a/test/remake_test.jl
+++ b/test/remake_test.jl
@@ -1,0 +1,41 @@
+using DiffEqJump, DiffEqBase
+
+rate = (u,p,t) -> p[1]*u[1]*u[2]
+affect! = function (integrator)
+  integrator.u[1] -= 1
+  integrator.u[2] += 1
+end
+jump = ConstantRateJump(rate,affect!)
+
+rate = (u,p,t) -> p[2]*u[2]
+affect! = function (integrator)
+  integrator.u[2] -= 1
+  integrator.u[3] += 1
+end
+jump2 = ConstantRateJump(rate,affect!)
+
+u0 = [999,1,0]
+p = (.1/1000,.01)
+tspan = (0.0,2500.0)
+
+dprob  = DiscreteProblem(u0,tspan,p)
+jprob = JumpProblem(dprob,Direct(),jump,jump2,save_positions=(false,false))
+sol = solve(jprob, SSAStepper())
+
+@test sol[1,end] == 0
+
+u02 = [1000,1,0]
+p2 = (0.0,.01)
+dprob2 = remake(dprob, u0=u02, p=p2)
+jprob2 = remake(jprob, prob=dprob2)
+sol2 = solve(jprob2, SSAStepper())
+@test sol2[1,end] == 1000
+
+tspan2 = (0.0, 250.0)
+jprob3 = remake(jprob, p=p2, tspan=tspan2)
+sol3 = solve(jprob3, SSAStepper())
+@test sol3[1,end] == 999
+
+# test error handling
+@test_throws ErrorException jprob4 = remake(jprob, prob=dprob2, p=p2)
+@test_throws ErrorException jprob5 = remake(jprob, aggregator=RSSA())

--- a/test/remake_test.jl
+++ b/test/remake_test.jl
@@ -30,10 +30,11 @@ jprob2 = remake(jprob, prob=dprob2)
 sol2 = solve(jprob2, SSAStepper())
 @test sol2[2,end] == 1001
 
-tspan2 = (0.0, 250.0)
+tspan2 = (0.0, 25000.0)
 jprob3 = remake(jprob, p=p2, tspan=tspan2)
 sol3 = solve(jprob3, SSAStepper())
 @test sol3[2,end] == 1000
+@test sol3.t[end] == 25000.0
 
 # test error handling
 @test_throws ErrorException jprob4 = remake(jprob, prob=dprob2, p=p2)

--- a/test/remake_test.jl
+++ b/test/remake_test.jl
@@ -24,16 +24,16 @@ sol = solve(jprob, SSAStepper())
 @test sol[1,end] == 0
 
 u02 = [1000,1,0]
-p2 = (0.0,.01)
+p2 = (.1/1000,0.0)
 dprob2 = remake(dprob, u0=u02, p=p2)
 jprob2 = remake(jprob, prob=dprob2)
 sol2 = solve(jprob2, SSAStepper())
-@test sol2[1,end] == 1000
+@test sol2[2,end] == 1001
 
 tspan2 = (0.0, 250.0)
 jprob3 = remake(jprob, p=p2, tspan=tspan2)
 sol3 = solve(jprob3, SSAStepper())
-@test sol3[1,end] == 999
+@test sol3[2,end] == 1000
 
 # test error handling
 @test_throws ErrorException jprob4 = remake(jprob, prob=dprob2, p=p2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,4 +19,5 @@ using DiffEqJump, DiffEqBase, Test
   @time @testset "Ensemble Uniqueness test" begin include("ensemble_uniqueness.jl") end
   @time @testset "Thread Safety test" begin include("thread_safety.jl") end
   @time @testset "A + B <--> C" begin include("reversible_binding.jl") end
+  @time @testset "Remake tests" begin include("remake_test.jl") end
 end


### PR DESCRIPTION
Should close https://github.com/SciML/DiffEqJump.jl/issues/97. 

Doesn't handle https://github.com/SciML/DiffEqJump.jl/issues/35. We don't know the mapping from a new `p` to the parameters in a `MassActionJump`, so we can't update it. We may need to just document how to update it, and provide a way to get the ordering (if they are reordered from a JumpSet in construction -- I need to check this).