### PR TITLE
Call initializer and finalizer for user callback in SSAIntegrator

### DIFF
--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -76,7 +76,7 @@ function DiffEqBase.__init(jump_prob::JumpProblem,
                          alias_jump = Threads.threadid() == 1,
                          saveat = nothing,
                          callback = nothing,
-                         tstops = (),
+                         tstops = [],
                          numsteps_hint=100)
     if !(jump_prob.prob isa DiscreteProblem)
         error("SSAStepper only supports DiscreteProblems.")
@@ -147,7 +147,7 @@ function DiffEqBase.__init(jump_prob::JumpProblem,
     integrator
 end
 
-function DiffEqBase.add_tstop!(integrator::SSAIntegrator{<:Any,<:Any,<:Any,<:Any,<:Any,<:Any,<:Any,<:Any,<:Vector},tstop)
+function DiffEqBase.add_tstop!(integrator::SSAIntegrator,tstop)
     insert_index = searchsortedfirst(integrator.tstops, tstop)
     if insert_index >= integrator.tstops_idx
         # we only insert the tstop if insert_index >= integrator.tstops_idx and thus

--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -148,10 +148,9 @@ function DiffEqBase.__init(jump_prob::JumpProblem,
 end
 
 function DiffEqBase.add_tstop!(integrator::SSAIntegrator,tstop)
-    insert_index = searchsortedfirst(integrator.tstops, tstop)
-    if insert_index >= integrator.tstops_idx
-        # we only insert the tstop if insert_index >= integrator.tstops_idx and thus
-        # ignore tstops in the past
+    if tstop > integrator.t
+        future_tstops = @view integrator.tstops[integrator.tstops_idx:end]
+        insert_index = integrator.tstops_idx + searchsortedfirst(future_tstops, tstop) - 1
         Base.insert!(integrator.tstops, insert_index, tstop) 
     end
 end

--- a/src/SSA_stepper.jl
+++ b/src/SSA_stepper.jl
@@ -64,6 +64,8 @@ function DiffEqBase.solve!(integrator)
         push!(integrator.sol.t,end_time)
         push!(integrator.sol.u,copy(integrator.u))
     end
+
+    DiffEqBase.finalize!(integrator.opts.callback, integrator.u, integrator.t, integrator)
 end
 
 function DiffEqBase.__init(jump_prob::JumpProblem,
@@ -141,6 +143,7 @@ function DiffEqBase.__init(jump_prob::JumpProblem,
                                cb,_saveat,save_everystep,save_end,cur_saveat,
                                opts,tstops,1,false,true)
     cb.initialize(cb,integrator.u,prob.tspan[1],integrator)
+    DiffEqBase.initialize!(opts.callback,integrator.u,prob.tspan[1],integrator)
     integrator
 end
 

--- a/test/ssa_callback_test.jl
+++ b/test/ssa_callback_test.jl
@@ -38,7 +38,7 @@ finalizer_called = 0
 fuel_finalize(cb, u, t, integrator) = global finalizer_called += 1
 
 cb2 = DiscreteCallback(condition, fuel_affect!, initialize=fuel_init!, finalize=fuel_finalize)
-sol = solve(jump_prob, SSAStepper(), callback=cb2, tstops=[])
+sol = solve(jump_prob, SSAStepper(), callback=cb2)
 for tstop in 1:9
   @test tstop ∈ sol.t
 end

--- a/test/ssa_callback_test.jl
+++ b/test/ssa_callback_test.jl
@@ -27,3 +27,19 @@ sol = solve(jump_prob, SSAStepper(), callback=cb, tstops=[5])
 
 @test sol.t[1:2] == [0.0, 5.0] # no jumps between t=0 and t=5
 @test sol(5 + 1e-10) == [100, 0] # state just after fueling before any decays can happen
+
+# test that callback initializer/finalizer is called and add_tstop! works as expected
+function fuel_init!(cb,u,t,integrator)
+  for tstop in 1:9
+    add_tstop!(integrator, tstop)
+  end
+end
+finalizer_called = 0
+fuel_finalize(cb, u, t, integrator) = global finalizer_called += 1
+
+cb2 = DiscreteCallback(condition, fuel_affect!, initialize=fuel_init!, finalize=fuel_finalize)
+sol = solve(jump_prob, SSAStepper(), callback=cb2, tstops=[])
+for tstop in 1:9
+  @test tstop ∈ sol.t
+end
+@test finalizer_called == 1


### PR DESCRIPTION
While `SSAIntegrator` can handle user callbacks in addition to the jump callbacks we are still missing some features from other solvers of the DiffEq ecosystem. This PR's intention is to add some of those features.

1. With this PR we call the initializer and finalizer functions of the user-provided callback as that is what the user will expect to happen.
2. Users may want to call `DiffEqBase.add_tstop!` inside a callback to dynamically add additional stopping points to `SSAIntegrator` during solve. Since `SSAIntegrator` does support `tstops` it makes sense to allow this. Note `add_tstop!` has to ensure that the `tstops` list always remains sorted. To avoid this extra work in the jump aggregators I added a specialized method `register_next_jump_time!` for `SSAIntegrator` that only updates one field. This should ensure that there are no performance regressions.

With these changes it is also possible to use `SSAIntegrators` with things like `PresetTimeCallback` from the callback library which adds `tstops` on callback initialize.