### PR TITLE
Fix reversible test

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,7 +33,6 @@ UnPack = "1.0.2"
 julia = "1.3"
 
 [extras]
-HypergeometricFunctions = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
@@ -42,4 +41,4 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["OrdinaryDiffEq", "SafeTestsets", "StableRNGs", "Statistics", "StochasticDiffEq", "Test", "HypergeometricFunctions"]
+test = ["OrdinaryDiffEq", "SafeTestsets", "StableRNGs", "Statistics", "StochasticDiffEq", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -33,6 +33,7 @@ UnPack = "1.0.2"
 julia = "1.3"
 
 [extras]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
@@ -41,4 +42,4 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["OrdinaryDiffEq", "SafeTestsets", "StableRNGs", "Statistics", "StochasticDiffEq", "Test"]
+test = ["LinearAlgebra","OrdinaryDiffEq", "SafeTestsets", "StableRNGs", "Statistics", "StochasticDiffEq", "Test"]

--- a/test/reversible_binding.jl
+++ b/test/reversible_binding.jl
@@ -30,7 +30,7 @@ function getmean(jprob,Nsims)
     Amean
 end
 
-function analyticmean(u, rates)
+function mastereqmean(u, rates)
     α = u[1]; β = u[2]; γ = u[3]
     d₊ = [rates[1]*(a+1)*(β-α+a+1) for a in 0:(α-1)]
     d₋ = [rates[2]*(γ+α-a+1) for a in 1:α]
@@ -41,7 +41,7 @@ function analyticmean(u, rates)
     P_a .= abs.(P_a)
     sum((a-1)*p for (a,p) in enumerate(P_a))
 end
-analytic_mean = analyticmean(u0, rates)
+mastereq_mean = mastereqmean(u0, rates)
 
 
 algs = DiffEqJump.JUMP_AGGREGATORS
@@ -49,5 +49,5 @@ relative_tolerance = 0.01
 for alg in algs
     local jprob = JumpProblem(prob,alg,majumps,save_positions=(false,false), rng=rng)
     local Amean = getmean(jprob, Nsims)
-    @test abs(Amean - analytic_mean)/analytic_mean < relative_tolerance    
+    @test abs(Amean - mastereq_mean)/mastereq_mean < relative_tolerance    
 end

--- a/test/reversible_binding.jl
+++ b/test/reversible_binding.jl
@@ -30,7 +30,6 @@ function getmean(jprob,Nsims)
     Amean
 end
 
-K = rates[1] / rates[2] 
 function analyticmean(u, rates)
     α = u[1]; β = u[2]; γ = u[3]
     d₊ = [rates[1]*(a+1)*(β-α+a+1) for a in 0:(α-1)]

--- a/test/reversible_binding.jl
+++ b/test/reversible_binding.jl
@@ -1,5 +1,5 @@
 using DiffEqJump, DiffEqBase
-using Test, HypergeometricFunctions
+using Test, LinearAlgebra
 using StableRNGs
 rng = StableRNG(12345)
 


### PR DESCRIPTION
@Vilin97 this fixes the test. I couldn't get the exact solution formula to work, even after checking it via several references, so I just switched the test to solve the corresponding master equation at steady-state and use that to calculate mean. I think there is either something wrong in the formula that is in the literature, or it is using a different Kummer function definition then special function libraries implement.