### PR TITLE
Allow MassActionJumps to use standard parameter vectors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqJump"
 uuid = "c894b116-72e5-5b58-be3c-e6d8d4ac2b12"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.15"
+version = "6.15.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -44,4 +44,4 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["LinearAlgebra","OrdinaryDiffEq", "SafeTestsets", "StableRNGs", "Statistics", "StochasticDiffEq", "Test"]
+test = ["LinearAlgebra", "OrdinaryDiffEq", "SafeTestsets", "StableRNGs", "Statistics", "StochasticDiffEq", "Test"]

--- a/src/aggregators/aggregated_api.jl
+++ b/src/aggregators/aggregated_api.jl
@@ -5,37 +5,40 @@ Reset the state of jump processes and associated solvers following a change
 in parameters or such.
 """
 
-function reset_aggregated_jumps!(integrator,uprev = nothing)
-     reset_aggregated_jumps!(integrator,uprev,integrator.opts.callback)
+function reset_aggregated_jumps!(integrator,uprev = nothing; update_jump_params=true)
+     reset_aggregated_jumps!(integrator,uprev,integrator.opts.callback,
+                             update_jump_params=update_jump_params)
      nothing
 end
 
-function reset_aggregated_jumps!(integrator,uprev,callback::Nothing)
+function reset_aggregated_jumps!(integrator,uprev,callback::Nothing; update_jump_params=true)
      nothing
 end
 
 
-function reset_aggregated_jumps!(integrator,uprev,callback::CallbackSet)
+function reset_aggregated_jumps!(integrator,uprev,callback::CallbackSet; update_jump_params=true)
     if !isempty(callback.discrete_callbacks)
-        reset_aggregated_jumps!(integrator,uprev,callback.discrete_callbacks...)
+        reset_aggregated_jumps!(integrator,uprev,callback.discrete_callbacks..., 
+                                update_jump_params=update_jump_params)
     end
     nothing
 end
 
-function reset_aggregated_jumps!(integrator,uprev,cb::DiscreteCallback,cbs...)
+function reset_aggregated_jumps!(integrator,uprev,cb::DiscreteCallback,cbs...; update_jump_params=true)
     if typeof(cb.condition) <: AbstractSSAJumpAggregator
         maj = cb.condition.ma_jumps
-        using_params(maj) && update_parameters!(cb.condition.ma_jumps,integrator.p)
+        update_jump_params && using_params(maj) && update_parameters!(cb.condition.ma_jumps,integrator.p)
         cb.condition(cb,integrator.u,integrator.t,integrator)
     end
-    reset_aggregated_jumps!(integrator,uprev,cbs...)
+    reset_aggregated_jumps!(integrator,uprev,cbs...; 
+                            update_jump_params=update_jump_params)
     nothing
 end
 
-function reset_aggregated_jumps!(integrator,uprev,cb::DiscreteCallback)
+function reset_aggregated_jumps!(integrator,uprev,cb::DiscreteCallback; update_jump_params=true)
     if typeof(cb.condition) <: AbstractSSAJumpAggregator
         maj = cb.condition.ma_jumps
-        using_params(maj) && update_parameters!(cb.condition.ma_jumps,integrator.p)
+        update_jump_params && using_params(maj) && update_parameters!(cb.condition.ma_jumps,integrator.p)
         cb.condition(cb,integrator.u,integrator.t,integrator)
     end
     nothing

--- a/src/aggregators/aggregated_api.jl
+++ b/src/aggregators/aggregated_api.jl
@@ -24,6 +24,8 @@ end
 
 function reset_aggregated_jumps!(integrator,uprev,cb::DiscreteCallback,cbs...)
     if typeof(cb.condition) <: AbstractSSAJumpAggregator
+        maj = cb.condition.ma_jumps
+        using_params(maj) && update_parameters!(cb.condition.ma_jumps,integrator.p)
         cb.condition(cb,integrator.u,integrator.t,integrator)
     end
     reset_aggregated_jumps!(integrator,uprev,cbs...)
@@ -32,6 +34,8 @@ end
 
 function reset_aggregated_jumps!(integrator,uprev,cb::DiscreteCallback)
     if typeof(cb.condition) <: AbstractSSAJumpAggregator
+        maj = cb.condition.ma_jumps
+        using_params(maj) && update_parameters!(cb.condition.ma_jumps,integrator.p)
         cb.condition(cb,integrator.u,integrator.t,integrator)
     end
     nothing

--- a/src/aggregators/aggregated_api.jl
+++ b/src/aggregators/aggregated_api.jl
@@ -1,8 +1,13 @@
 """
-    reset_aggregated_jumps!(integrator,uprev = nothing)
+    reset_aggregated_jumps!(integrator,uprev = nothing; update_jump_params=true)
 
 Reset the state of jump processes and associated solvers following a change
 in parameters or such.
+
+Notes
+    - `update_jump_params=true` will recalculate the rates stored within any 
+      MassActionJump that was built from the parameter vector. If the parameter
+      vector is unchanged this can safely be set to false to improve performance.
 """
 
 function reset_aggregated_jumps!(integrator,uprev = nothing; update_jump_params=true)

--- a/src/aggregators/aggregated_api.jl
+++ b/src/aggregators/aggregated_api.jl
@@ -1,7 +1,7 @@
 """
     reset_aggregated_jumps!(integrator,uprev = nothing)
 
-Reset the state of jump processes and associated solvers following a changed
+Reset the state of jump processes and associated solvers following a change
 in parameters or such.
 """
 

--- a/src/aggregators/aggregated_api.jl
+++ b/src/aggregators/aggregated_api.jl
@@ -1,3 +1,10 @@
+"""
+    reset_aggregated_jumps!(integrator,uprev = nothing)
+
+Reset the state of jump processes and associated solvers following a changed
+in parameters or such.
+"""
+
 function reset_aggregated_jumps!(integrator,uprev = nothing)
      reset_aggregated_jumps!(integrator,uprev,integrator.opts.callback)
      nothing

--- a/src/aggregators/ssajump.jl
+++ b/src/aggregators/ssajump.jl
@@ -80,7 +80,8 @@ function build_jump_aggregation(jump_agg_type, u, p, t, end_time, ma_jumps, rate
     if majumps === nothing
         majumps = MassActionJump(Vector{typeof(t)}(),
                              Vector{Vector{Pair{Int,eltype(u)}}}(),
-                             Vector{Vector{Pair{Int,eltype(u)}}}())
+                             Vector{Vector{Pair{Int,eltype(u)}}}(),
+                             Vector{Int}())
     end
 
     # current jump rates, allows mass action rates and constant jumps

--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -100,19 +100,24 @@ end
 
 using_params(maj::MassActionJump{U,V,W,Vector{Int}}) where {U,V,W} = !isempty(maj.param_idxs)
 using_params(maj::MassActionJump{U,V,W,Int}) where {U,V,W} = (maj.param_idxs > 0)
+using_params(maj::Nothing) = false
+
 @inline get_num_majumps(maj::MassActionJump) = length(maj.scaled_rates)
 @inline get_num_majumps(maj::Nothing) = 0
 
 """
-  update!(maj::MassActionJump{T,S,U,V}, newparams; scale_rates=true)
+  update_parameters!(maj::MassActionJump, newparams; scale_rates=true)
 
 Updates the passed in MassActionJump with the parameter values in `newparams`.
 
 Notes:
   - Requires the jump to have been constructed with a user-passed `param_idxs`.
+  - `scale_rates=true` will scale the parameter representing the jump rate by an
+    appropriate combinatoric factor. i.e for 3A --> B at rate k it will scale
+    k --> k/3!.
 """
-function update!(maj::MassActionJump{T,S,U,V}, newparams; scale_rates=true, kwargs...) where {T <: AbstractVector, S, U, V}    
-  ((maj.param_idxs isa AbstractArray) && (!isempty(maj.param_idxs))) || error("The passed in MassActionJump's param_idxs field is either empty or not an AbstractArray.")
+function update_parameters!(maj::MassActionJump{T,S,U,V}, newparams; scale_rates=true, kwargs...) where {T <: AbstractVector, S, U, V}    
+  ((maj.param_idxs isa AbstractArray) && using_params(maj)) || error("The passed in MassActionJump's param_idxs field is either empty or not an AbstractArray.")
   for i in 1:get_num_majumps(maj)
     maj.scaled_rates[i] = newparams[maj.param_idxs[i]]
     scale_rates && scalerate(maj.scaled_rates[i], maj.reactant_stoch[i])

--- a/src/jumps.jl
+++ b/src/jumps.jl
@@ -90,6 +90,7 @@ MassActionJump(usr::T, rs, ns; scale_rates = true, useiszero = true, nocopy=fals
 # with parameter indices 
 function MassActionJump(rs::AbstractVector{S}, ns; param_idxs, params, kwargs...) where {S <: AbstractArray}
   param_idxs isa AbstractArray || error("When creating a MassActionJump representing multiple jumps, param_idxs must be a vector.")  
+  length(param_idxs) == length(rs) || error("For each jump within a MassActionJump there must be a corresponding index in param_idxs.")
   MassActionJump([params[pidx] for pidx in param_idxs], rs, ns, param_idxs; kwargs...)
 end
 

--- a/src/massaction_rates.jl
+++ b/src/massaction_rates.jl
@@ -4,7 +4,7 @@
 ###############################################################################
 
 @inline @fastmath function evalrxrate(speciesvec::AbstractVector{T}, rxidx::S,
-                              majump::MassActionJump{U,V,W})::R where {T,S,R,U <: AbstractVector{R},V,W}
+                              majump::MassActionJump{U,V,W,X})::R where {T,S,R,U <: AbstractVector{R},V,W,X}
     val = one(T)
     @inbounds for specstoch in majump.reactant_stoch[rxidx]
         specpop = speciesvec[specstoch[1]]
@@ -19,7 +19,7 @@
 end
 
 @inline @fastmath function executerx!(speciesvec::AbstractVector{T}, rxidx::S,
-                                      majump::MassActionJump{U,V,W}) where {T,S,U,V,W}
+                                      majump::MassActionJump{U,V,W,X}) where {T,S,U,V,W,X}
     @inbounds net_stoch = majump.net_stoch[rxidx]
     @inbounds for specstoch in net_stoch
         speciesvec[specstoch[1]] += specstoch[2]
@@ -28,7 +28,7 @@ end
 end
 
 @inline @fastmath function executerx(speciesvec::SVector{T}, rxidx::S,
-                                      majump::MassActionJump{U,V,W}) where {T,S,U,V,W}
+                                      majump::MassActionJump{U,V,W,X}) where {T,S,U,V,W,X}
     @inbounds net_stoch = majump.net_stoch[rxidx]
     @inbounds for specstoch in net_stoch
         speciesvec = setindex(speciesvec,speciesvec[specstoch[1]]+specstoch[2],specstoch[1])

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -33,9 +33,19 @@ function DiffEqBase.remake(thing::JumpProblem; kwargs...)
 
   if :prob ∉ keys(kwargs)
     dprob = DiffEqBase.remake(thing.prob; kwargs...)
+
+    # if the parameters were changed we must remake the MassActionJump too
+    if (:p ∈ keys(kwargs)) && using_params(thing.massaction_jump)
+      update!(thing.massaction_jump, dprob.p; kwargs...)
+    end 
   else
     any(k -> k in keys(kwargs), (:u0,:p,:tspan)) && error("If remaking a JumpProblem you can not pass both prob and any of u0, p, or tspan.")
     dprob = kwargs[:prob]
+
+    # we can't know if p was changed, so we must remake the MassActionJump
+    if using_params(thing.massaction_jump)
+      update!(thing.massaction_jump, dprob.p; kwargs...)
+    end 
   end
 
   T(dprob, thing.aggregator, thing.discrete_jump_aggregation, thing.jump_callback,

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -36,7 +36,7 @@ function DiffEqBase.remake(thing::JumpProblem; kwargs...)
 
     # if the parameters were changed we must remake the MassActionJump too
     if (:p ∈ keys(kwargs)) && using_params(thing.massaction_jump)
-      update!(thing.massaction_jump, dprob.p; kwargs...)
+      update_parameters!(thing.massaction_jump, dprob.p; kwargs...)
     end 
   else
     any(k -> k in keys(kwargs), (:u0,:p,:tspan)) && error("If remaking a JumpProblem you can not pass both prob and any of u0, p, or tspan.")
@@ -44,7 +44,7 @@ function DiffEqBase.remake(thing::JumpProblem; kwargs...)
 
     # we can't know if p was changed, so we must remake the MassActionJump
     if using_params(thing.massaction_jump)
-      update!(thing.massaction_jump, dprob.p; kwargs...)
+      update_parameters!(thing.massaction_jump, dprob.p; kwargs...)
     end 
   end
 

--- a/test/degenerate_rx_cases.jl
+++ b/test/degenerate_rx_cases.jl
@@ -119,3 +119,19 @@ if doplot
     display(plothand)
     display(plothand2)
 end
+
+# check MassActionJump with parameters merge together correctly
+rs1 = [1 => 1]
+rs2 = [2=>1]
+ns1 = [1 => -1, 2 => 1]
+ns2 = [1=>1,2=>-1]
+p  = [1.0,0.0]
+maj1 = MassActionJump(rs1, ns1; param_idxs=1, params=p)
+maj2 = MassActionJump(rs2, ns2; param_idxs=2, params=p)
+js   = JumpSet(maj1,maj2)
+maj  = MassActionJump([rs1,rs2],[ns1,ns2]; param_idxs=[1,2], params=p)
+@test all(getfield(maj,fn) == getfield(js.massaction_jump,fn) for fn in fieldnames(typeof(maj)))
+maj1 = MassActionJump([rs1], [ns1]; param_idxs=[1], params=p)
+maj2 = MassActionJump([rs2], [ns2]; param_idxs=[2], params=p)
+js   = JumpSet(maj1,maj2)
+@test all(getfield(maj,fn) == getfield(js.massaction_jump,fn) for fn in fieldnames(typeof(maj)))

--- a/test/remake_test.jl
+++ b/test/remake_test.jl
@@ -23,7 +23,7 @@ tspan = (0.0,2500.0)
 dprob  = DiscreteProblem(u0,tspan,p)
 jprob = JumpProblem(dprob,Direct(),jump,jump2,save_positions=(false,false), rng=rng)
 sol = solve(jprob, SSAStepper())
-@test sol[1,end] == 0
+@test sol[3,end] == 1000
 
 u02 = [1000,1,0]
 p2 = (.1/1000,0.0)
@@ -37,6 +37,31 @@ jprob3 = remake(jprob, p=p2, tspan=tspan2)
 sol3 = solve(jprob3, SSAStepper())
 @test sol3[2,end] == 1000
 @test sol3.t[end] == 25000.0
+
+################ test changing MassActionJump parameters
+rng = StableRNG(12345)
+rs = [[2=>1],[1 => 1, 2 => 1]]
+ns = [[2 => -1, 3 => 1],[1 => -1, 2 => 1]]
+pidxs = [2,1]
+maj   = MassActionJump(rs, ns; param_idxs=pidxs, params=p)
+dprob = DiscreteProblem(u0,tspan,p[pidxs])
+jprob = JumpProblem(dprob, Direct(), maj, save_positions=(false,false), rng=rng)
+sol   = solve(jprob, SSAStepper())
+@test sol[3,end] == 1000
+
+# update the MassActionJump
+dprob2 = remake(dprob, u0=u02, p=p2)
+jprob2 = remake(jprob, prob=dprob2)
+sol2 = solve(jprob2, SSAStepper())
+@test sol2[2,end] == 1001
+
+tspan2 = (0.0, 25000.0)
+jprob3 = remake(jprob, p=p2, tspan=tspan2)
+sol3 = solve(jprob3, SSAStepper())
+@test sol3[2,end] == 1000
+@test sol3.t[end] == 25000.0
+
+#################
 
 # test error handling
 @test_throws ErrorException jprob4 = remake(jprob, prob=dprob2, p=p2)


### PR DESCRIPTION
This should allow a new `MassActionJump` use case
```
p = (1.0, 2.0)

# use 2.0 for the first reaction rate and 1.0 for the second
MassActionJump(reaction_stoich, net_stoich; param_idxs=[2,1], params=p)
```
while preserving compatibility with the old style. Rates are still fixed at construction time, but in this mode they are read from the parameter vector `p` according to the indices in `param_idxs`. This ordering is then saved so that later one can use an updated parameter vector/tuple to update a mass action jump (if it was setup in this way, otherwise the old style will still work just fine).

@ChrisRackauckas if you think this approach makes sense I'll add in a function for remaking in callbacks, which we can subsequently point users too.