### PR TITLE
Pass kwargs when resetting aggregators

### DIFF
--- a/src/aggregators/aggregated_api.jl
+++ b/src/aggregators/aggregated_api.jl
@@ -10,41 +10,41 @@ Notes
       vector is unchanged this can safely be set to false to improve performance.
 """
 
-function reset_aggregated_jumps!(integrator,uprev = nothing; update_jump_params=true)
+function reset_aggregated_jumps!(integrator,uprev = nothing; update_jump_params=true, kwargs...)
      reset_aggregated_jumps!(integrator,uprev,integrator.opts.callback,
-                             update_jump_params=update_jump_params)
+                             update_jump_params=update_jump_params, kwargs...)
      nothing
 end
 
-function reset_aggregated_jumps!(integrator,uprev,callback::Nothing; update_jump_params=true)
+function reset_aggregated_jumps!(integrator,uprev,callback::Nothing; update_jump_params=true, kwargs...)
      nothing
 end
 
 
-function reset_aggregated_jumps!(integrator,uprev,callback::CallbackSet; update_jump_params=true)
+function reset_aggregated_jumps!(integrator,uprev,callback::CallbackSet; update_jump_params=true, kwargs...)
     if !isempty(callback.discrete_callbacks)
         reset_aggregated_jumps!(integrator,uprev,callback.discrete_callbacks..., 
-                                update_jump_params=update_jump_params)
+                                update_jump_params=update_jump_params, kwargs...)
     end
     nothing
 end
 
-function reset_aggregated_jumps!(integrator,uprev,cb::DiscreteCallback,cbs...; update_jump_params=true)
+function reset_aggregated_jumps!(integrator,uprev,cb::DiscreteCallback,cbs...; update_jump_params=true, kwargs...)
     if typeof(cb.condition) <: AbstractSSAJumpAggregator
         maj = cb.condition.ma_jumps
-        update_jump_params && using_params(maj) && update_parameters!(cb.condition.ma_jumps,integrator.p)
+        update_jump_params && using_params(maj) && update_parameters!(cb.condition.ma_jumps,integrator.p; kwargs...)
         cb.condition(cb,integrator.u,integrator.t,integrator)
     end
     reset_aggregated_jumps!(integrator,uprev,cbs...; 
-                            update_jump_params=update_jump_params)
+                            update_jump_params=update_jump_params, kwargs...)
     nothing
 end
 
-function reset_aggregated_jumps!(integrator,uprev,cb::DiscreteCallback; update_jump_params=true)
+function reset_aggregated_jumps!(integrator,uprev,cb::DiscreteCallback; update_jump_params=true, kwargs...)
     if typeof(cb.condition) <: AbstractSSAJumpAggregator
         maj = cb.condition.ma_jumps
-        update_jump_params && using_params(maj) && update_parameters!(cb.condition.ma_jumps,integrator.p)
-        cb.condition(cb,integrator.u,integrator.t,integrator)
+        update_jump_params && using_params(maj) && update_parameters!(cb.condition.ma_jumps,integrator.p; kwargs...)
+        cb.condition(cb,integrator.u,integrator.t,integrator; kwargs...)
     end
     nothing
 end

--- a/src/aggregators/aggregated_api.jl
+++ b/src/aggregators/aggregated_api.jl
@@ -44,7 +44,7 @@ function reset_aggregated_jumps!(integrator,uprev,cb::DiscreteCallback; update_j
     if typeof(cb.condition) <: AbstractSSAJumpAggregator
         maj = cb.condition.ma_jumps
         update_jump_params && using_params(maj) && update_parameters!(cb.condition.ma_jumps,integrator.p; kwargs...)
-        cb.condition(cb,integrator.u,integrator.t,integrator; kwargs...)
+        cb.condition(cb,integrator.u,integrator.t,integrator)
     end
     nothing
 end


### PR DESCRIPTION
Allows users to pass `scale_rates` through to MassActionJumps when resetting aggregators.