### PR TITLE
added `reset!` for `PriorityTable`

### DIFF
--- a/src/aggregators/directcr.jl
+++ b/src/aggregators/directcr.jl
@@ -57,8 +57,7 @@ function DirectCRJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
     ratetogroup = rate -> priortogid(rate, minexponent)
 
     # construct an empty initial priority table -- we'll reset this in init
-    num_jumps = length(crs)
-    rt = PriorityTable(ratetogroup, zeros(T, num_jumps), minrate, 2*minrate)
+    rt = PriorityTable(ratetogroup, zeros(T, 1), minrate, 2*minrate)
 
     DirectCRJumpAggregation{T,S,F1,F2,RNG,typeof(dg),typeof(rt),typeof(ratetogroup)}(
                                             nj, nj, njt, et, crs, sr, maj, rs, affs!, sps, rng,

--- a/src/aggregators/directcr.jl
+++ b/src/aggregators/directcr.jl
@@ -56,11 +56,9 @@ function DirectCRJumpAggregation(nj::Int, njt::T, et::T, crs::Vector{T}, sr::T,
     minrate = 2.0^minexponent
     ratetogroup = rate -> priortogid(rate, minexponent)
 
-    # construct an empty initial priority table -- we'll overwrite this in init anyways...
-    rt = PriorityTable{T,Int,Int,typeof(ratetogroup)}(minrate, 2*minrate,
-                                                        Vector{PriorityGroup{T,Vector{Int}}}(),
-                                                        Vector{T}(), zero(T),
-                                                        Vector{Tuple{Int,Int}}(), ratetogroup)
+    # construct an empty initial priority table -- we'll reset this in init
+    num_jumps = length(crs)
+    rt = PriorityTable(ratetogroup, zeros(T, num_jumps), minrate, 2*minrate)
 
     DirectCRJumpAggregation{T,S,F1,F2,RNG,typeof(dg),typeof(rt),typeof(ratetogroup)}(
                                             nj, nj, njt, et, crs, sr, maj, rs, affs!, sps, rng,
@@ -87,11 +85,11 @@ function initialize!(p::DirectCRJumpAggregation, integrator, u, params, t)
     # initialize rates
     fill_rates_and_sum!(p, u, params, t)
 
-    # if no maxrate was set, use largest initial rate (pad by 2 for an extra group)
-    isinf(p.maxrate) && (p.maxrate = 2*maximum(p.cur_rates))
-
     # setup PriorityTable
-    p.rt   = PriorityTable(p.ratetogroup, p.cur_rates, p.minrate, p.maxrate)
+    reset!(p.rt)
+    for (pid,priority) in enumerate(p.cur_rates)
+        insert!(p.rt, pid, priority)
+    end
 
     generate_jumps!(p, integrator, u, params, t)
     nothing

--- a/src/aggregators/prioritytable.jl
+++ b/src/aggregators/prioritytable.jl
@@ -159,7 +159,6 @@ end
 # i.e. pid = length(pidtogroup) + 1
 function insert!(pt::PriorityTable, pid, priority)
     @unpack maxpriority, groups, gsums, pidtogroup, priortogid = pt
-    pidtype = typeof(pid)
 
     # find group for new priority
     gid = priortogid(priority)
@@ -225,6 +224,16 @@ function update!(pt::PriorityTable, pid, oldpriority, newpriority)
         end
     end
     nothing
+end
+
+function reset!(pt::PriorityTable{F,S,T,U}) where {F,S,T,U}
+    @unpack groups, gsums, pidtogroup = pt
+    pt.gsum       = zero(F)
+    fill!(gsums, zero(F))
+    fill!(pidtogroup, (zero(T),zero(T)))
+    for group in groups
+        group.numpids = zero(T)
+    end
 end
 
 function Base.show(io::IO, pt::PriorityTable)

--- a/src/aggregators/prioritytable.jl
+++ b/src/aggregators/prioritytable.jl
@@ -228,7 +228,7 @@ end
 
 function reset!(pt::PriorityTable{F,S,T,U}) where {F,S,T,U}
     @unpack groups, gsums, pidtogroup = pt
-    pt.gsum       = zero(F)
+    pt.gsum = zero(F)
     fill!(gsums, zero(F))
     fill!(pidtogroup, (zero(T),zero(T)))
     for group in groups

--- a/src/aggregators/rssacr.jl
+++ b/src/aggregators/rssacr.jl
@@ -76,8 +76,7 @@ function RSSACRJumpAggregation(nj::Int, njt::F, et::F, crs::Vector{F}, sum_rate:
     ratetogroup = rate -> priortogid(rate, minexponent)
 
     # construct an empty initial priority table -- we'll reset this in init
-    num_jumps = length(crs)
-    rt = PriorityTable(ratetogroup, zeros(F, num_jumps), minrate, 2*minrate)
+    rt = PriorityTable(ratetogroup, zeros(F, 1), minrate, 2*minrate)
 
     RSSACRJumpAggregation{typeof(njt),eltype(U),S,F1,F2,RNG,typeof(vtoj_map),typeof(jtov_map),typeof(bd),typeof(ulow),typeof(rt),typeof(ratetogroup)}(
                             nj, nj, njt, et, crl_bnds, crh_bnds, sum_rate, maj, rs, affs!, sps, rng, vtoj_map, 


### PR DESCRIPTION
Wrote a `reset!` function for the `PriorityTable` used in `DirectCR` and `RSSACR`. This slightly reduces allocations per run, since a new table does not get allocated every time. Here is a benchmark for before and after. There is a small improvement
![image](https://user-images.githubusercontent.com/17322558/127247811-d8523ee1-337f-428f-928c-1a0d74fdd06a.png)
