### PR TITLE
Improved `HopRatesGeneral`

### DIFF
--- a/src/spatial/flatten.jl
+++ b/src/spatial/flatten.jl
@@ -25,7 +25,7 @@ function flatten(netstoch::AbstractArray, reactstoch::AbstractArray, rx_rates::A
     hop_constants = Matrix{Vector{F}}(undef, size(hopping_constants))
     for ci in CartesianIndices(hop_constants)
         (species, site) = Tuple(ci)
-        hop_constants[ci] = repeat([hopping_constants[species, site]], num_neighbors(spatial_system, site))
+        hop_constants[ci] = hopping_constants[species, site] * ones(num_neighbors(spatial_system, site))
     end
     flatten(netstoch, reactstoch, rx_rates, spatial_system, u0, tspan, hop_constants; kwargs...)
 end

--- a/src/spatial/flatten.jl
+++ b/src/spatial/flatten.jl
@@ -33,7 +33,7 @@ end
 """
 if reaction rates is a vector, assume reaction rates are equal across sites
 """
-function flatten(netstoch::AbstractArray, reactstoch::AbstractArray, rx_rates::Vector, spatial_system, u0::Matrix{Int}, tspan, hopping_constants::Vector{Matrix{F}}; kwargs...) where F <: Number
+function flatten(netstoch::AbstractArray, reactstoch::AbstractArray, rx_rates::Vector, spatial_system, u0::Matrix{Int}, tspan, hopping_constants::Matrix{Vector{F}}; kwargs...) where F <: Number
     num_nodes = num_sites(spatial_system)
     rates = reshape(repeat(rx_rates, num_nodes), length(rx_rates), num_nodes)
     flatten(netstoch, reactstoch, rates, spatial_system, u0, tspan, hopping_constants; kwargs...)

--- a/src/spatial/flatten.jl
+++ b/src/spatial/flatten.jl
@@ -18,18 +18,15 @@ function flatten(ma_jump, prob::DiscreteProblem, spatial_system, hopping_constan
 end
 
 """
-if hopping_constants is a matrix, assume hopping_constants[i,j] is species i, site j
+if hopping_constants is a matrix, assume hopping_constants[i,j] is the hopping constant of species i from site j to any neighbor
 """
 function flatten(netstoch::AbstractArray, reactstoch::AbstractArray, rx_rates::AbstractArray, spatial_system, u0::Matrix{Int}, tspan, hopping_constants::Matrix{F}; kwargs...) where F <: Number
-    num_nodes = num_sites(spatial_system)
-    num_specs = size(u0, 1)
-    @assert size(hopping_constants) == size(u0) # hopping_constants[i,j] is species i, site j
-    hop_constants = Vector{Matrix{F}}(undef, size(hopping_constants, 2))
-    for site in 1:num_nodes
-        num_nbs = num_neighbors(spatial_system, site)
-        hop_constants[site] = reshape(repeat((@view hopping_constants[:,site]), num_nbs), num_specs, num_nbs)
+    @assert size(hopping_constants) == size(u0)
+    hop_constants = Matrix{Vector{F}}(undef, size(hopping_constants))
+    for ci in CartesianIndices(hop_constants)
+        (species, site) = Tuple(ci)
+        hop_constants[ci] = repeat([hopping_constants[species, site]], num_neighbors(spatial_system, site))
     end
-    
     flatten(netstoch, reactstoch, rx_rates, spatial_system, u0, tspan, hop_constants; kwargs...)
 end
 
@@ -45,11 +42,12 @@ end
 """
 "flatten" the spatial jump problem. Return flattened DiscreteProblem and MassActionJump.
 """
-function flatten(netstoch::Vector{R}, reactstoch::Vector{R}, rx_rates::Matrix{F}, spatial_system, u0::Matrix{Int}, tspan, hopping_constants::Vector{Matrix{F}}; scale_rates = true, kwargs...) where {R, F <: Number}
+function flatten(netstoch::Vector{R}, reactstoch::Vector{R}, rx_rates::Matrix{F}, spatial_system, u0::Matrix{Int}, tspan, hopping_constants::Matrix{Vector{F}}; scale_rates = true, kwargs...) where {R, F <: Number}
     num_species = size(u0, 1)
     num_nodes = num_sites(spatial_system)
     num_rxs = length(reactstoch)
-    @assert length(hopping_constants) == size(u0, 2) == size(rx_rates, 2) == num_nodes
+    @assert size(hopping_constants) == size(u0)
+    @assert size(u0, 2) == size(rx_rates, 2) == num_nodes
     @assert length(netstoch) == length(reactstoch) == size(rx_rates, 1) == num_rxs
     spec_CI = CartesianIndices((num_species, num_nodes))
     spec_LI = LinearIndices((num_species, num_nodes))
@@ -61,16 +59,16 @@ function flatten(netstoch::Vector{R}, reactstoch::Vector{R}, rx_rates::Matrix{F}
     total_rates = F[]; sizehint!(total_rates, num_jumps)
 
     #hops
-    # assuming hopping_constants isa Vector{Matrix} where hopping_constants[src][species, index] is the hop const of species from src to neighbor at index in neighbors(spatial_system, src)
+    # assuming hopping_constants isa Matrix{Vector} where hopping_constants[species, src][index] is the hop const of species from src to neighbor at index in neighbors(spatial_system, src)
     for src in 1:num_nodes
-        hopping_constants_at_src = hopping_constants[src]
-        for (i,dst) in enumerate(neighbors(spatial_system, src))
-            for species in 1:num_species
+        for species in 1:num_species
+        hopping_const = hopping_constants[species, src]
+            for (i,dst) in enumerate(neighbors(spatial_system, src))
                 dst_idx = spec_LI[spec_CI[species,dst]]
                 src_idx = spec_LI[spec_CI[species,src]]
                 push!(total_netstoch, [dst_idx => 1, src_idx => -1])
                 push!(total_reactstoch, [src_idx => 1])
-                push!(total_rates, hopping_constants_at_src[species, i])
+                push!(total_rates, hopping_const[i])
             end
         end
     end

--- a/src/spatial/utils.jl
+++ b/src/spatial/utils.jl
@@ -266,23 +266,19 @@ end
 
 ############## hopping rates of form L_{s,i,j} ################
 struct HopRatesGeneral{F} <: AbstractHopRates
-    hop_const_cumulative_sums::Vector{Matrix{F}} # hop_const_cumulative_sums[i][j,s] is the cumulative sum of 
-    hopping_constants::Vector{Matrix{F}} # hopping_constants[i][j,s] is the hopping constant at site i of species s to jth neighbor
-    rates::Matrix{F} # rates[s,i] is the hopping rate of species s at site i
+    hop_const_cumulative_sums::Matrix{Vector{F}} # hop_const_cumulative_sums[s,i] is the vector of cumulative sums of hopping constants of species s at site i
+    rates::Matrix{F} # rates[s,i] is the total hopping rate of species s at site i
     sum_rates::Vector{F} # sum_rates[i] is the total hopping rate out of site i
 end
 
 """
 initializes HopRates with zero rates
 """
-function HopRatesGeneral(hopping_constants::Vector{Matrix{F}}, transpose = true) where F <: Number
-    if transpose
-        hopping_constants = map(r -> r = collect(r'), hopping_constants) #transpose for better memory layout
-    end
-    rates = deepcopy(hopping_constants)
-    foreach(r -> r .= zero(F), rates)
-    sum_rates = zeros(F, length(rates))
-    HopRatesGeneral{F}(hopping_constants, rates, sum_rates)
+function HopRatesGeneral(hopping_constants::Matrix{Vector{F}}) where F <: Number
+    hop_const_cumulative_sums = map(cumsum, hopping_constants)
+    rates = zeros(F, size(hopping_constants))
+    sum_rates = vec(sum(rates, dims=1))
+    HopRatesGeneral{F}(hop_const_cumulative_sums, rates, sum_rates)
 end
 
 """
@@ -298,9 +294,9 @@ end
 sample a reaction at site, return (species, target_site)
 """
 function sample_hop_at_site(hop_rates::HopRatesGeneral, site, rng, spatial_system) 
-    @inbounds rates_at_site = hop_rates.rates[:,site]
-    r = rand(rng) * total_site_hop_rate(hop_rates, site)
-    n, species = Tuple(CartesianIndices(rates_at_site)[linear_search(rates_at_site, r)])
+    species = linear_search((@view hop_rates.rates[:,site]), rand(rng) * total_site_hop_rate(hop_rates, site))
+    cumulative_hop_constants = hop_const_cumulative_sums[species, site]
+    n = searchsortedfirst(cumulative_hop_constants, rand(rng) * cumulative_hop_constants[end])
     return species, nth_nbr(spatial_system, site, n)
 end
 
@@ -308,10 +304,10 @@ end
 update rates of single species at site
 """
 function update_hop_rate!(hop_rates::HopRatesGeneral, species, u, site, spatial_system)
-    rates_at_site = hop_rates.rates[site]
-    @inbounds old_rate = sum(@view rates_at_site[:,species])
-    @inbounds @. rates_at_site[:,species] = (@view hop_rates.hopping_constants[site][:,species]) * u[species,site]
-    @inbounds hop_rates.sum_rates[site] += sum(@view rates_at_site[:,species]) - old_rate
+    rates = hop_rates.rates
+    @inbounds old_rate = rates[species, site]
+    rates[species, site] = u[species, site] * hop_rates.hop_const_cumulative_sums[species, site][end]
+    @inbounds hop_rates.sum_rates[site] += rates[species, site] - old_rate
     old_rate
 end
 

--- a/src/spatial/utils.jl
+++ b/src/spatial/utils.jl
@@ -294,9 +294,9 @@ end
 sample a reaction at site, return (species, target_site)
 """
 function sample_hop_at_site(hop_rates::HopRatesGeneral, site, rng, spatial_system) 
-    species = linear_search((@view hop_rates.rates[:,site]), rand(rng) * total_site_hop_rate(hop_rates, site))
-    cumulative_hop_constants = hop_rates.hop_const_cumulative_sums[species, site]
-    n = searchsortedfirst(cumulative_hop_constants, rand(rng) * cumulative_hop_constants[end])
+    @inbounds species = linear_search((@view hop_rates.rates[:,site]), rand(rng) * total_site_hop_rate(hop_rates, site))
+    @inbounds cumulative_hop_constants = hop_rates.hop_const_cumulative_sums[species, site]
+    @inbounds n = searchsortedfirst(cumulative_hop_constants, rand(rng) * cumulative_hop_constants[end])
     return species, nth_nbr(spatial_system, site, n)
 end
 
@@ -306,7 +306,7 @@ update rates of single species at site
 function update_hop_rate!(hop_rates::HopRatesGeneral, species, u, site, spatial_system)
     rates = hop_rates.rates
     @inbounds old_rate = rates[species, site]
-    rates[species, site] = u[species, site] * hop_rates.hop_const_cumulative_sums[species, site][end]
+    @inbounds rates[species, site] = u[species, site] * hop_rates.hop_const_cumulative_sums[species, site][end]
     @inbounds hop_rates.sum_rates[site] += rates[species, site] - old_rate
     old_rate
 end

--- a/src/spatial/utils.jl
+++ b/src/spatial/utils.jl
@@ -266,8 +266,9 @@ end
 
 ############## hopping rates of form L_{s,i,j} ################
 struct HopRatesGeneral{F} <: AbstractHopRates
+    hop_const_cumulative_sums::Vector{Matrix{F}} # hop_const_cumulative_sums[i][j,s] is the cumulative sum of 
     hopping_constants::Vector{Matrix{F}} # hopping_constants[i][j,s] is the hopping constant at site i of species s to jth neighbor
-    rates::Vector{Matrix{F}} # rates[i][j,s] is the hopping rate at site i of species s to jth neighbor
+    rates::Matrix{F} # rates[s,i] is the hopping rate of species s at site i
     sum_rates::Vector{F} # sum_rates[i] is the total hopping rate out of site i
 end
 
@@ -297,7 +298,7 @@ end
 sample a reaction at site, return (species, target_site)
 """
 function sample_hop_at_site(hop_rates::HopRatesGeneral, site, rng, spatial_system) 
-    @inbounds rates_at_site = hop_rates.rates[site]
+    @inbounds rates_at_site = hop_rates.rates[:,site]
     r = rand(rng) * total_site_hop_rate(hop_rates, site)
     n, species = Tuple(CartesianIndices(rates_at_site)[linear_search(rates_at_site, r)])
     return species, nth_nbr(spatial_system, site, n)

--- a/src/spatial/utils.jl
+++ b/src/spatial/utils.jl
@@ -201,7 +201,7 @@ total_site_hop_rate(hop_rates::AbstractHopRates, site) = @inbounds hop_rates.sum
 ############## hopping rates of form L_{s,i} ################
 
 HopRates(hopping_constants::Matrix{F}) where F <: Number = HopRatesUnifNbr(hopping_constants)
-HopRates(hopping_constants::Vector{Matrix{F}}) where F <: Number = HopRatesGeneral(hopping_constants)
+HopRates(hopping_constants::AbstractArray) where F <: Number = HopRatesGeneral(hopping_constants)
 
 struct HopRatesUnifNbr{F} <: AbstractHopRates
     hopping_constants::Matrix{F} # hopping_constants[i,j] is the hop constant of species i at site j
@@ -285,7 +285,7 @@ end
 make all rates zero
 """
 function reset!(hop_rates::HopRatesGeneral{F}) where F <: Number
-    foreach(r -> fill!(r, zero(F)), hop_rates.rates)
+    hop_rates.rates .= zero(F)
     hop_rates.sum_rates .= zero(F)
     nothing
 end
@@ -295,7 +295,7 @@ sample a reaction at site, return (species, target_site)
 """
 function sample_hop_at_site(hop_rates::HopRatesGeneral, site, rng, spatial_system) 
     species = linear_search((@view hop_rates.rates[:,site]), rand(rng) * total_site_hop_rate(hop_rates, site))
-    cumulative_hop_constants = hop_const_cumulative_sums[species, site]
+    cumulative_hop_constants = hop_rates.hop_const_cumulative_sums[species, site]
     n = searchsortedfirst(cumulative_hop_constants, rand(rng) * cumulative_hop_constants[end])
     return species, nth_nbr(spatial_system, site, n)
 end

--- a/test/spatial/ABC.jl
+++ b/test/spatial/ABC.jl
@@ -48,7 +48,7 @@ end
 # testing on CartesianGrid
 grids = [DiffEqJump.CartesianGridRej(dims), DiffEqJump.CartesianGridIter(dims), LightGraphs.grid(dims)]
 jump_problems = JumpProblem[JumpProblem(prob, alg, majumps, hopping_constants=hopping_constants, spatial_system = grid, save_positions=(false,false)) for grid in grids]
-# setup flattenned jump prob
+# add flattenned jump prob
 push!(jump_problems, JumpProblem(prob, NRM(), majumps, hopping_constants=hopping_constants, spatial_system = grids[end], save_positions=(false,false)))
 # test
 for spatial_jump_prob in jump_problems

--- a/test/spatial/utils_test.jl
+++ b/test/spatial/utils_test.jl
@@ -78,12 +78,13 @@ for site in 1:num_nodes
 end
 
 # Tests for HopRatesGeneral
-hopping_constants = Vector{Matrix{Float64}}(undef, num_nodes)
-for site in 1:num_nodes
-    hopping_constants[site] = ones(num_species, DiffEqJump.num_neighbors(g, site))
+hop_constants = Matrix{Vector{Float64}}(undef, num_species, num_nodes)
+for ci in CartesianIndices(hop_constants)
+    (species, site) = Tuple(ci)
+    hop_constants[ci] = repeat([1.0], DiffEqJump.num_neighbors(g, site))
 end
 spec_probs = ones(num_species)/num_species
-hop_rates = DiffEqJump.HopRatesGeneral(hopping_constants)
+hop_rates = DiffEqJump.HopRatesGeneral(hop_constants)
 
 for site in 1:num_nodes
     DiffEqJump.update_hop_rates!(hop_rates, 1:num_species, u, site, g)


### PR DESCRIPTION
Now `HopRatesGeneral` uses cumulative sums of hopping constants avoiding unnecessary summations and vector operations. Also improved the interface so that hopping constants are now passed in as Matrix{Vector}, with [s,i] being vector of hopping constants of species s at site i to its neighbors