### PR TITLE
Import initialize!

### DIFF
--- a/src/DiffEqJump.jl
+++ b/src/DiffEqJump.jl
@@ -8,7 +8,7 @@ using DataStructures, PoissonRandom, Random, ArrayInterface
 using FunctionWrappers, UnPack
 using LightGraphs
 
-import DiffEqBase: DiscreteCallback, init, solve, solve!, plot_indices
+import DiffEqBase: DiscreteCallback, init, solve, solve!, plot_indices, initialize!
 import Base: size, getindex, setindex!, length, similar, show, merge!, merge
 import DataStructures: update!
 import LightGraphs: neighbors


### PR DESCRIPTION
```julia
julia> pop = read_pumas(pkdata,
                       observations = [:dv], 
                       covariates = [:age, :wt, :doselevel, :isPM, :isfed, :sex])
Population
  Subjects: 18
  Covariates: age, wt, doselevel, isPM, isfed, sex
  Observations: WARNING: both OrdinaryDiffEq and DiffEqJump export "initialize!"; uses of it in module Pumas must be qualified
dv
```

Some dispatch must be shadowing instead of extending DiffEqBase, so this is a quick fix.