### PR TITLE
Now the general form of hopping rates with a cartesian grid is faster

### DIFF
--- a/src/DiffEqJump.jl
+++ b/src/DiffEqJump.jl
@@ -43,10 +43,10 @@ include("aggregators/rssacr.jl")
 include("aggregators/rdirect.jl")
 
 # spatial:
-include("spatial/flatten.jl")
+include("spatial/topology.jl")
 include("spatial/hop_rates.jl")
 include("spatial/reaction_rates.jl")
-include("spatial/topology.jl")
+include("spatial/flatten.jl")
 include("spatial/utils.jl")
 
 include("spatial/nsm.jl")

--- a/src/spatial/DirectCRDirect.jl
+++ b/src/spatial/DirectCRDirect.jl
@@ -75,7 +75,7 @@ function aggregate(aggregator::DirectCRDirect, starting_state, p, t, end_time, c
     next_jump = SpatialJump{Int}(typemax(Int),typemax(Int),typemax(Int)) #a placeholder
     next_jump_time = typemax(typeof(end_time))
     rx_rates = RxRates(num_sites(spatial_system), majumps)
-    hop_rates = HopRates(hopping_constants)
+    hop_rates = HopRates(hopping_constants, spatial_system)
     site_rates = zeros(typeof(end_time), num_sites(spatial_system))
 
     DirectCRDirectJumpAggregation(next_jump, next_jump_time, end_time, rx_rates, hop_rates, site_rates, save_positions, rng, spatial_system; num_specs = num_species, kwargs...)

--- a/src/spatial/hop_rates.jl
+++ b/src/spatial/hop_rates.jl
@@ -4,6 +4,12 @@ A file with structs and functions for sampling hops and updating hopping rates
 
 ### spatial hop rates ###
 abstract type AbstractHopRates end
+
+HopRates(hopping_constants::Matrix{F}, spatial_system) where F <: Number = HopRatesUnifNbr(hopping_constants)
+HopRates(hopping_constants::Matrix{F}, grid::Union{CartesianGridRej, CartesianGridIter}) where F <: Number = HopRatesUnifNbr(hopping_constants)
+HopRates(hopping_constants::AbstractArray, spatial_system) = HopRatesGeneral(hopping_constants)
+HopRates(hopping_constants::AbstractArray, grid::Union{CartesianGridRej, CartesianGridIter}) = HopRatesGeneralGrid(hopping_constants, grid)
+
 """
     update_hop_rates!(hop_rates::AbstractHopRates, species::AbstractArray, u, site, spatial_system)
 
@@ -17,19 +23,17 @@ end
 
 """
     total_site_hop_rate(hop_rates::AbstractHopRates, site)
-    
+
 return total hopping rate out of site
 """
 total_site_hop_rate(hop_rates::AbstractHopRates, site) = @inbounds hop_rates.sum_rates[site]
 
 ############## hopping rates of form L_{s,i} ################
 
-HopRates(hopping_constants::Matrix{F}) where F <: Number = HopRatesUnifNbr(hopping_constants)
-HopRates(hopping_constants::AbstractArray) where F <: Number = HopRatesGeneral(hopping_constants)
 
 struct HopRatesUnifNbr{F} <: AbstractHopRates
     "hopping_constants[i,j] is the hop constant of species i at site j"
-    hopping_constants::Matrix{F} 
+    hopping_constants::Matrix{F}
 
     "rates[i,j] is total hopping rate of species i at site j"
     rates::Matrix{F}
@@ -65,22 +69,22 @@ function reset!(hop_rates::HopRatesUnifNbr)
 end
 
 """
-    sample_hop_at_site(hop_rates::HopRatesUnifNbr, site, rng, spatial_system) 
+    sample_hop_at_site(hop_rates::HopRatesUnifNbr, site, rng, spatial_system)
 
 sample a reaction at site, return (species, target_site)
 """
-function sample_hop_at_site(hop_rates::HopRatesUnifNbr, site, rng, spatial_system) 
+function sample_hop_at_site(hop_rates::HopRatesUnifNbr, site, rng, spatial_system)
     species = linear_search(hop_rates_at_site(hop_rates, site), rand(rng) * total_site_hop_rate(hop_rates, site))
     target_site = rand_nbr(spatial_system, site)
     return species, target_site
 end
 
 """
-    update_hop_rate!(hop_rates::HopRatesUnifNbr, species::Int, u, site, spatial_system) 
+    update_hop_rate!(hop_rates::HopRatesUnifNbr, species::Int, u, site, spatial_system)
 
 update rates of single species at site
 """
-function update_hop_rate!(hop_rates::HopRatesUnifNbr, species::Int, u, site, spatial_system) 
+function update_hop_rate!(hop_rates::HopRatesUnifNbr, species::Int, u, site, spatial_system)
     set_hop_rate_at_site!(hop_rates, site, species, evalhoprate(hop_rates, u, species, site, num_neighbors(spatial_system, site)))
 end
 
@@ -88,14 +92,14 @@ end
 """
 returns hopping rates of a site
 """
-function hop_rates_at_site(hop_rates::HopRatesUnifNbr, site) 
+function hop_rates_at_site(hop_rates::HopRatesUnifNbr, site)
     @view hop_rates.rates[:,site]
 end
 
 """
 sets the rate of hopping at site. Return the old rate
 """
-function set_hop_rate_at_site!(hop_rates::HopRatesUnifNbr, site, species, rate) 
+function set_hop_rate_at_site!(hop_rates::HopRatesUnifNbr, site, species, rate)
     @inbounds old_rate = hop_rates.rates[species, site]
     @inbounds hop_rates.rates[species, site] = rate
     @inbounds hop_rates.sum_rates[site] += rate - old_rate
@@ -104,14 +108,14 @@ end
 """
 return hopping rate of species at site
 """
-function evalhoprate(hop_rates::HopRatesUnifNbr, u, species, site, num_nbs::Int) 
+function evalhoprate(hop_rates::HopRatesUnifNbr, u, species, site, num_nbs::Int)
     @inbounds u[species,site]*hop_rates.hopping_constants[species,site]*num_nbs
 end
 
 ############## hopping rates of form L_{s,i,j} ################
 struct HopRatesGeneral{F} <: AbstractHopRates
     "hop_const_cumulative_sums[s,i] is the vector of cumulative sums of hopping constants of species s at site i"
-    hop_const_cumulative_sums::Matrix{Vector{F}} 
+    hop_const_cumulative_sums::Matrix{Vector{F}}
 
     "rates[s,i] is the total hopping rate of species s at site i"
     rates::Matrix{F}
@@ -149,14 +153,14 @@ function reset!(hop_rates::HopRatesGeneral{F}) where F <: Number
 end
 
 """
-    sample_hop_at_site(hop_rates::HopRatesGeneral, site, rng, spatial_system) 
+    sample_hop_at_site(hop_rates::HopRatesGeneral, site, rng, spatial_system)
 
 sample a reaction at site, return (species, target_site)
 """
-function sample_hop_at_site(hop_rates::HopRatesGeneral, site, rng, spatial_system) 
-    species = linear_search((@view hop_rates.rates[:,site]), rand(rng) * total_site_hop_rate(hop_rates, site))
-    cumulative_hop_constants = hop_rates.hop_const_cumulative_sums[species, site]
-    n = searchsortedfirst(cumulative_hop_constants, rand(rng) * cumulative_hop_constants[end])
+function sample_hop_at_site(hop_rates::HopRatesGeneral, site, rng, spatial_system)
+    @inbounds species = linear_search((@view hop_rates.rates[:,site]), rand(rng) * total_site_hop_rate(hop_rates, site))
+    @inbounds cumulative_hop_constants = hop_rates.hop_const_cumulative_sums[species, site]
+    @inbounds n = searchsortedfirst(cumulative_hop_constants, rand(rng) * cumulative_hop_constants[end])
     return species, nth_nbr(spatial_system, site, n)
 end
 
@@ -168,7 +172,84 @@ update rates of single species at site
 function update_hop_rate!(hop_rates::HopRatesGeneral, species, u, site, spatial_system)
     rates = hop_rates.rates
     @inbounds old_rate = rates[species, site]
-    rates[species, site] = u[species, site] * hop_rates.hop_const_cumulative_sums[species, site][end]
+    @inbounds rates[species, site] = u[species, site] * hop_rates.hop_const_cumulative_sums[species, site][end]
+    @inbounds hop_rates.sum_rates[site] += rates[species, site] - old_rate
+    old_rate
+end
+
+#################  HopRatesGeneralGrid  ######################
+"""
+Analogue of HopRatesGeneral but for CartesianGrid
+"""
+struct HopRatesGeneralGrid{F} <: AbstractHopRates
+    "hop_const_cumulative_sums[:,s,i] is the vector of cumulative sums of hopping constants of species s at site i"
+    hop_const_cumulative_sums::Array{F, 3}
+
+    "rates[s,i] is the total hopping rate of species s at site i"
+    rates::Matrix{F}
+
+    "sum_rates[i] is the total hopping rate out of site i"
+    sum_rates::Vector{F}
+end
+
+function Base.show(io::IO, ::MIME"text/plain", hop_rates::HopRatesGeneralGrid)
+    num_specs, num_sites = size(hop_rates.rates)
+    println(io, "HopRates with $num_specs species and $num_sites sites, optimized for CartesianGrid. \nHopping constants of form L_{s,i,j} where s is species, i is source and j is destination.")
+end
+
+"""
+    HopRatesGeneralGrid(hopping_constants::Matrix{Vector{F}}) where F <: Number
+
+initializes HopRates with zero rates
+"""
+function HopRatesGeneralGrid(hopping_constants::Array{F, 3}) where F <: Number
+    hop_const_cumulative_sums = mapslices(cumsum, hopping_constants, dims = 1)
+    rates = zeros(F, size(hopping_constants)[2:3])
+    sum_rates = vec(sum(rates, dims=1))
+    HopRatesGeneralGrid{F}(hop_const_cumulative_sums, rates, sum_rates)
+end
+
+function HopRatesGeneralGrid(hopping_constants::Matrix{Vector{F}}, grid) where F <: Number
+    new_hopping_constants = Array{F, 3}(undef, 2*dimension(grid), size(hopping_constants)...)
+    for ci in CartesianIndices(hopping_constants)
+        species, site = Tuple(ci)
+        new_hopping_constants[:, species, site] = pad_hop_vec(grid, site, hopping_constants[ci])
+    end
+    HopRatesGeneralGrid(new_hopping_constants)
+end
+
+"""
+    reset!(hop_rates::HopRatesGeneralGrid{F})
+
+make all rates zero
+"""
+function reset!(hop_rates::HopRatesGeneralGrid{F}) where F <: Number
+    hop_rates.rates .= zero(F)
+    hop_rates.sum_rates .= zero(F)
+    nothing
+end
+
+"""
+    sample_hop_at_site(hop_rates::HopRatesGeneralGrid, site, rng, spatial_system)
+
+sample a reaction at site, return (species, target_site)
+"""
+function sample_hop_at_site(hop_rates::HopRatesGeneralGrid, site, rng, grid::Union{CartesianGridRej, CartesianGridIter})
+    @inbounds species = linear_search((@view hop_rates.rates[:,site]), rand(rng) * total_site_hop_rate(hop_rates, site))
+    @inbounds cumulative_hop_constants = @view hop_rates.hop_const_cumulative_sums[:,species, site]
+    @inbounds n = searchsortedfirst(cumulative_hop_constants, rand(rng) * cumulative_hop_constants[end])
+    return species, nth_potential_nbr(grid, site, n)
+end
+
+"""
+    update_hop_rate!(hop_rates::HopRatesGeneralGrid, species, u, site, spatial_system)
+
+update rates of single species at site
+"""
+function update_hop_rate!(hop_rates::HopRatesGeneralGrid, species, u, site, spatial_system)
+    rates = hop_rates.rates
+    @inbounds old_rate = rates[species, site]
+    @inbounds rates[species, site] = u[species, site] * hop_rates.hop_const_cumulative_sums[end, species, site]
     @inbounds hop_rates.sum_rates[site] += rates[species, site] - old_rate
     old_rate
 end

--- a/src/spatial/hop_rates.jl
+++ b/src/spatial/hop_rates.jl
@@ -54,7 +54,7 @@ initializes HopRatesUnifNbr with zero rates
 """
 function HopRatesUnifNbr(hopping_constants::Matrix{F}) where F <: Number
     rates = zeros(F, size(hopping_constants))
-    HopRatesUnifNbr{F}(hopping_constants, rates, sum_rates = zeros(F, size(rates, 2)))
+    HopRatesUnifNbr{F}(hopping_constants, rates, zeros(F, size(rates, 2)))
 end
 
 """
@@ -203,7 +203,7 @@ end
 initializes HopRates with zero rates
 """
 function HopRatesGeneralGrid(hopping_constants::Array{F, 3}; do_cumsum = true) where F <: Number
-    do_cumsum && hopping_constants = mapslices(cumsum, hopping_constants, dims = 1)
+    do_cumsum && (hopping_constants = mapslices(cumsum, hopping_constants, dims = 1))
     rates = zeros(F, size(hopping_constants)[2:3])
     sum_rates = zeros(F, size(rates, 2))
     HopRatesGeneralGrid{F}(hopping_constants, rates, sum_rates)

--- a/src/spatial/nsm.jl
+++ b/src/spatial/nsm.jl
@@ -65,7 +65,7 @@ function aggregate(aggregator::NSM, starting_state, p, t, end_time, constant_jum
     next_jump = SpatialJump{Int}(typemax(Int),typemax(Int),typemax(Int)) #a placeholder
     next_jump_time = typemax(typeof(end_time))
     rx_rates = RxRates(num_sites(spatial_system), majumps)
-    hop_rates = HopRates(hopping_constants)
+    hop_rates = HopRates(hopping_constants, spatial_system)
 
     NSMJumpAggregation(next_jump, next_jump_time, end_time, rx_rates, hop_rates, save_positions, rng, spatial_system; num_specs = num_species, kwargs...)
 end

--- a/src/spatial/topology.jl
+++ b/src/spatial/topology.jl
@@ -36,7 +36,7 @@ num_neighbors(grid, site) = grid.nums_neighbors[site]
 """
     nth_potential_nbr(grid, site, n)
 
-return nth potential neighbor (it might be out of bounds)
+return nth Cartesian neighbor ignoring boundaries
 """
 nth_potential_nbr(grid, site, n) = grid.LI[grid.offsets[n]+grid.CI[site]]
 
@@ -70,21 +70,21 @@ function neighbors(grid, site)
 end
 
 """
-given a vector of hopping constants of length num_nbs(grid, site), return a vector of size 2*(dimension of grid) with zeros at indices where the neighbor is out of bounds
+given a vector of hopping constants of length num_neighbors(grid, site), form the vector of size 2*(dimension of grid) with zeros at indices where the neighbor is out of bounds. Store it in to_pad
 """
-function pad_hop_vec(grid, site, hop_vec::Vector{F}) where F <: Number
-    length(hop_vec) == 2*dimension(grid) && return hop_vec
-    new_hop_vec = zeros(2*dimension(grid))
-    CI = grid.CI; offsets = grid.offsets
-    @inbounds I = CI[site]
+function pad_hop_vec!(to_pad::Vector{F}, grid, site, hop_vec::Vector{F}) where F <: Number
+    CI = grid.CI
+    I = CI[site]
     nbr_counter = 1
     for (i,off) in enumerate(grid.offsets)
         if I + off in CI
-            new_hop_vec[i] = hop_vec[nbr_counter]
+            to_pad[i] = hop_vec[nbr_counter]
             nbr_counter += 1
+        else
+            to_pad[i] = zero(F)
         end
     end
-    new_hop_vec
+    to_pad
 end
 
 # neighbor sampling is rejection-based

--- a/src/spatial/topology.jl
+++ b/src/spatial/topology.jl
@@ -72,7 +72,7 @@ end
 """
 given a vector of hopping constants of length num_neighbors(grid, site), form the vector of size 2*(dimension of grid) with zeros at indices where the neighbor is out of bounds. Store it in to_pad
 """
-function pad_hop_vec!(to_pad::Vector{F}, grid, site, hop_vec::Vector{F}) where F <: Number
+function pad_hop_vec!(to_pad::AbstractVector{F}, grid, site, hop_vec::Vector{F}) where F <: Number
     CI = grid.CI
     I = CI[site]
     nbr_counter = 1

--- a/src/spatial/topology.jl
+++ b/src/spatial/topology.jl
@@ -29,8 +29,16 @@ function potential_offsets(dimension::Int)
     end
 end
 
+dimension(grid) = length(grid.dims)
 num_sites(grid) = prod(grid.dims)
 num_neighbors(grid, site) = grid.nums_neighbors[site]
+
+"""
+    nth_potential_nbr(grid, site, n)
+
+return nth potential neighbor (it might be out of bounds)
+"""
+nth_potential_nbr(grid, site, n) = grid.LI[grid.offsets[n]+grid.CI[site]]
 
 """
     nth_nbr(grid, site, n)
@@ -52,13 +60,31 @@ end
 """
     neighbors(grid, site)
 
-return neighbors of site in ascending order
+return an iterator over neighbors of site in ascending order. Do not use in hot loops
 """
 function neighbors(grid, site)
     CI = grid.CI
     LI = grid.LI
     I = CI[site]
     Iterators.map(off -> LI[off+I], Iterators.filter(off -> off+I in CI, grid.offsets))
+end
+
+"""
+given a vector of hopping constants of length num_nbs(grid, site), return a vector of size 2*(dimension of grid) with zeros at indices where the neighbor is out of bounds
+"""
+function pad_hop_vec(grid, site, hop_vec::Vector{F}) where F <: Number
+    length(hop_vec) == 2*dimension(grid) && return hop_vec
+    new_hop_vec = zeros(2*dimension(grid))
+    CI = grid.CI; offsets = grid.offsets
+    @inbounds I = CI[site]
+    nbr_counter = 1
+    for (i,off) in enumerate(grid.offsets)
+        if I + off in CI
+            new_hop_vec[i] = hop_vec[nbr_counter]
+            nbr_counter += 1
+        end
+    end
+    new_hop_vec
 end
 
 # neighbor sampling is rejection-based

--- a/test/spatial/diffusion.jl
+++ b/test/spatial/diffusion.jl
@@ -63,7 +63,7 @@ grids = [CartesianGridRej(dims), CartesianGridIter(dims), LightGraphs.grid(dims)
 jump_problems = JumpProblem[JumpProblem(prob, NSM(), majumps, hopping_constants=hopping_constants, spatial_system = grid, save_positions=(false,false)) for grid in grids]
 push!(jump_problems, JumpProblem(prob, DirectCRDirect(), majumps, hopping_constants=hopping_constants, spatial_system = grids[1], save_positions=(false,false)))
 # setup flattenned jump prob
-graph = LightGraphs.grid(dims)
+graph = grids[1]
 push!(jump_problems, JumpProblem(prob, NRM(), majumps, hopping_constants=hopping_constants, spatial_system = graph, save_positions=(false,false)))
 # hop rates of form L_{s,i,j}
 hop_constants = Matrix{Vector{Float64}}(undef, size(hopping_constants))


### PR DESCRIPTION
wrote HopRatesGeneralGrid -- an optimized version of `HopRatesGeneral` for cartesian grids. It takes about twice less time to sample a neighbor now.