### PR TITLE
Attempt to fix complex states with VariableRateJumps

### DIFF
--- a/src/problem.jl
+++ b/src/problem.jl
@@ -191,10 +191,9 @@ function extend_problem(prob::DiffEqBase.AbstractODEProblem,jumps)
   function jump_f(du::ExtendedJumpArray,u::ExtendedJumpArray,p,t)
     prob.f(du.u,u.u,p,t)
     update_jumps!(du,u,p,t,length(u.u),jumps.variable_jumps...)
-  end
-  T = realtype(eltype(prob.u0))
+  end  
   ttype = eltype(prob.tspan)
-  u0 = ExtendedJumpArray(prob.u0,[T(-randexp(ttype)) for i in 1:length(jumps.variable_jumps)])
+  u0 = ExtendedJumpArray(prob.u0,[-randexp(ttype) for i in 1:length(jumps.variable_jumps)])
   remake(prob,f=ODEFunction{true}(jump_f),u0=u0)
 end
 
@@ -214,9 +213,8 @@ function extend_problem(prob::DiffEqBase.AbstractSDEProblem,jumps)
     end
   end
 
-  T = realtype(eltype(prob.u0))
   ttype = eltype(prob.tspan)
-  u0 = ExtendedJumpArray(prob.u0,[T(-randexp(ttype)) for i in 1:length(jumps.variable_jumps)])
+  u0 = ExtendedJumpArray(prob.u0,[-randexp(ttype) for i in 1:length(jumps.variable_jumps)])
   remake(prob,f=SDEFunction{true}(jump_f,jump_g),g=jump_g,u0=u0)
 end
 
@@ -225,9 +223,8 @@ function extend_problem(prob::DiffEqBase.AbstractDDEProblem,jumps)
     prob.f(du.u,u.u,h,p,t)
     update_jumps!(du,u,p,t,length(u.u),jumps.variable_jumps...)
   end
-  T = realtype(eltype(prob.u0))
   ttype = eltype(prob.tspan)
-  u0 = ExtendedJumpArray(prob.u0,[T(-randexp(ttype)) for i in 1:length(jumps.variable_jumps)])
+  u0 = ExtendedJumpArray(prob.u0,[-randexp(ttype) for i in 1:length(jumps.variable_jumps)])
   ramake(prob,f=DDEFunction{true}(jump_f),u0=u0)
 end
 
@@ -237,9 +234,8 @@ function extend_problem(prob::DiffEqBase.AbstractDAEProblem,jumps)
     prob.f(out.u,du.u,u.u,t)
     update_jumps!(du,u,t,length(u.u),jumps.variable_jumps...)
   end
-  T = realtype(eltype(prob.u0))
   ttype = eltype(prob.tspan)
-  u0 = ExtendedJumpArray(prob.u0,[T(-randexp(ttype)) for i in 1:length(jumps.variable_jumps)])
+  u0 = ExtendedJumpArray(prob.u0,[-randexp(ttype) for i in 1:length(jumps.variable_jumps)])
   remake(prob,f=DAEFunction{true}(jump_f),u0=u0)
 end
 

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -189,7 +189,8 @@ function extend_problem(prob::DiffEqBase.AbstractODEProblem,jumps)
     update_jumps!(du,u,p,t,length(u.u),jumps.variable_jumps...)
   end
   T = eltype(prob.u0)
-  u0 = ExtendedJumpArray(prob.u0,[T(-randexp()) for i in 1:length(jumps.variable_jumps)])
+  ttype = eltype(prob.tspan)
+  u0 = ExtendedJumpArray(prob.u0,[T(-randexp(ttype)) for i in 1:length(jumps.variable_jumps)])
   remake(prob,f=ODEFunction{true}(jump_f),u0=u0)
 end
 
@@ -210,7 +211,8 @@ function extend_problem(prob::DiffEqBase.AbstractSDEProblem,jumps)
   end
 
   T = eltype(prob.u0)
-  u0 = ExtendedJumpArray(prob.u0,[T(-randexp()) for i in 1:length(jumps.variable_jumps)])
+  ttype = eltype(prob.tspan)
+  u0 = ExtendedJumpArray(prob.u0,[T(-randexp(ttype)) for i in 1:length(jumps.variable_jumps)])
   remake(prob,f=SDEFunction{true}(jump_f,jump_g),g=jump_g,u0=u0)
 end
 
@@ -220,7 +222,8 @@ function extend_problem(prob::DiffEqBase.AbstractDDEProblem,jumps)
     update_jumps!(du,u,p,t,length(u.u),jumps.variable_jumps...)
   end
   T = eltype(prob.u0)
-  u0 = ExtendedJumpArray(prob.u0,[T(-randexp()) for i in 1:length(jumps.variable_jumps)])
+  ttype = eltype(prob.tspan)
+  u0 = ExtendedJumpArray(prob.u0,[T(-randexp(ttype)) for i in 1:length(jumps.variable_jumps)])
   ramake(prob,f=DDEFunction{true}(jump_f),u0=u0)
 end
 
@@ -231,7 +234,8 @@ function extend_problem(prob::DiffEqBase.AbstractDAEProblem,jumps)
     update_jumps!(du,u,t,length(u.u),jumps.variable_jumps...)
   end
   T = eltype(prob.u0)
-  u0 = ExtendedJumpArray(prob.u0,[T(-randexp()) for i in 1:length(jumps.variable_jumps)])
+  ttype = eltype(prob.tspan)
+  u0 = ExtendedJumpArray(prob.u0,[T(-randexp(ttype)) for i in 1:length(jumps.variable_jumps)])
   remake(prob,f=DAEFunction{true}(jump_f),u0=u0)
 end
 
@@ -242,7 +246,7 @@ function build_variable_callback(cb,idx,jump,jumps...)
   end
   affect! = function (integrator)
     jump.affect!(integrator)
-    integrator.u.jump_u[idx] = -randexp()
+    integrator.u.jump_u[idx] = -randexp(typeof(integrator.t))
   end
   new_cb = ContinuousCallback(condition,affect!;
                       idxs = jump.idxs,
@@ -261,7 +265,7 @@ function build_variable_callback(cb,idx,jump)
   end
   affect! = function (integrator)
     jump.affect!(integrator)
-    integrator.u.jump_u[idx] = -randexp()
+    integrator.u.jump_u[idx] = -randexp(typeof(integrator.t))
   end
   new_cb = ContinuousCallback(condition,affect!;
                       idxs = jump.idxs,

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -82,7 +82,7 @@ mutable struct JumpProblem{iip,P,A,C,J<:Union{Nothing,AbstractJumpAggregator},J2
 end
 function JumpProblem(p::P,a::A,dj::J,jc::C,vj::J2,rj::J3,mj::J4,rng::R) where {P,A,J,C,J2,J3,J4,R}
     iip = isinplace_jump(p,rj)
-    JumpProblem{iip,P,A,C,J,J2,J3,J4,R}(p,a,dj,jc,vj,rj,mj,R)
+    JumpProblem{iip,P,A,C,J,J2,J3,J4,R}(p,a,dj,jc,vj,rj,mj,rng)
 end
 
 # for remaking
@@ -113,7 +113,7 @@ function DiffEqBase.remake(thing::JumpProblem; kwargs...)
   end
 
   T(dprob, thing.aggregator, thing.discrete_jump_aggregation, thing.jump_callback,
-     thing.variable_jumps, thing.regular_jump, thing.massaction_jump)
+     thing.variable_jumps, thing.regular_jump, thing.massaction_jump, thing.rng)
 end
 
 DiffEqBase.isinplace(::JumpProblem{iip}) where {iip} = iip

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -183,10 +183,6 @@ function extend_problem(prob::DiffEqBase.AbstractDiscreteProblem,jumps)
   error("VariableRateJumps require a continuous problem, like an ODE/SDE/DDE/DAE problem.")
 end
 
-realtype(::Type{Complex{T}}) where {T <: Real} = T
-realtype(::Type{T}) where {T <: Real} = T
-realtype(::Type{T}) where T = error("Can not determinte if $T is real or complex.")
-
 function extend_problem(prob::DiffEqBase.AbstractODEProblem,jumps)
   function jump_f(du::ExtendedJumpArray,u::ExtendedJumpArray,p,t)
     prob.f(du.u,u.u,p,t)

--- a/src/problem.jl
+++ b/src/problem.jl
@@ -183,12 +183,16 @@ function extend_problem(prob::DiffEqBase.AbstractDiscreteProblem,jumps)
   error("VariableRateJumps require a continuous problem, like an ODE/SDE/DDE/DAE problem.")
 end
 
+realtype(::Type{Complex{T}}) where {T <: Real} = T
+realtype(::Type{T}) where {T <: Real} = T
+realtype(::Type{T}) where T = error("Can not determinte if $T is real or complex.")
+
 function extend_problem(prob::DiffEqBase.AbstractODEProblem,jumps)
   function jump_f(du::ExtendedJumpArray,u::ExtendedJumpArray,p,t)
     prob.f(du.u,u.u,p,t)
     update_jumps!(du,u,p,t,length(u.u),jumps.variable_jumps...)
   end
-  T = eltype(prob.u0)
+  T = realtype(eltype(prob.u0))
   ttype = eltype(prob.tspan)
   u0 = ExtendedJumpArray(prob.u0,[T(-randexp(ttype)) for i in 1:length(jumps.variable_jumps)])
   remake(prob,f=ODEFunction{true}(jump_f),u0=u0)
@@ -210,7 +214,7 @@ function extend_problem(prob::DiffEqBase.AbstractSDEProblem,jumps)
     end
   end
 
-  T = eltype(prob.u0)
+  T = realtype(eltype(prob.u0))
   ttype = eltype(prob.tspan)
   u0 = ExtendedJumpArray(prob.u0,[T(-randexp(ttype)) for i in 1:length(jumps.variable_jumps)])
   remake(prob,f=SDEFunction{true}(jump_f,jump_g),g=jump_g,u0=u0)
@@ -221,7 +225,7 @@ function extend_problem(prob::DiffEqBase.AbstractDDEProblem,jumps)
     prob.f(du.u,u.u,h,p,t)
     update_jumps!(du,u,p,t,length(u.u),jumps.variable_jumps...)
   end
-  T = eltype(prob.u0)
+  T = realtype(eltype(prob.u0))
   ttype = eltype(prob.tspan)
   u0 = ExtendedJumpArray(prob.u0,[T(-randexp(ttype)) for i in 1:length(jumps.variable_jumps)])
   ramake(prob,f=DDEFunction{true}(jump_f),u0=u0)
@@ -233,7 +237,7 @@ function extend_problem(prob::DiffEqBase.AbstractDAEProblem,jumps)
     prob.f(out.u,du.u,u.u,t)
     update_jumps!(du,u,t,length(u.u),jumps.variable_jumps...)
   end
-  T = eltype(prob.u0)
+  T = realtype(eltype(prob.u0))
   ttype = eltype(prob.tspan)
   u0 = ExtendedJumpArray(prob.u0,[T(-randexp(ttype)) for i in 1:length(jumps.variable_jumps)])
   remake(prob,f=DAEFunction{true}(jump_f),u0=u0)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -45,7 +45,7 @@ function resetted_jump_problem(_jump_prob,seed)
 
   if !isempty(jump_prob.variable_jumps)
     @assert jump_prob.prob.u0 isa ExtendedJumpArray    
-    jump_prob.prob.u0.jump_u .= -randexp.(eltype(_jump_prob.prob.tspan))
+    jump_prob.prob.u0.jump_u .= -randexp.(_jump_prob.rng,eltype(_jump_prob.prob.tspan))
   end
   jump_prob
 end
@@ -57,6 +57,6 @@ function reset_jump_problem!(jump_prob,seed)
 
   if !isempty(jump_prob.variable_jumps)
     @assert jump_prob.prob.u0 isa ExtendedJumpArray
-    jump_prob.prob.u0.jump_u .= -randexp.(eltype(jump_prob.prob.tspan))
+    jump_prob.prob.u0.jump_u .= -randexp.(jump_prob.rng,eltype(jump_prob.prob.tspan))
   end
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -44,9 +44,8 @@ function resetted_jump_problem(_jump_prob,seed)
   end
 
   if !isempty(jump_prob.variable_jumps)
-    @assert jump_prob.prob.u0 isa ExtendedJumpArray
-    randexp!(jump_prob.prob.u0.jump_u)
-    jump_prob.prob.u0.jump_u .*= -1
+    @assert jump_prob.prob.u0 isa ExtendedJumpArray    
+    jump_prob.prob.u0.jump_u .= -randexp.(eltype(_jump_prob.prob.tspan))
   end
   jump_prob
 end
@@ -58,7 +57,6 @@ function reset_jump_problem!(jump_prob,seed)
 
   if !isempty(jump_prob.variable_jumps)
     @assert jump_prob.prob.u0 isa ExtendedJumpArray
-    randexp!(jump_prob.prob.u0.jump_u)
-    jump_prob.prob.u0.jump_u .*= -1
+    jump_prob.prob.u0.jump_u .= -randexp.(eltype(jump_prob.prob.tspan))
   end
 end

--- a/test/variable_rate.jl
+++ b/test/variable_rate.jl
@@ -128,3 +128,18 @@ affect3!(integrator) = (integrator.u[1] = 0.25; integrator.u[2] = 0.5;
 jump = VariableRateJump(rate3, affect3!)
 jump_prob = JumpProblem(prob, Direct(), jump; rng=rng)
 sol = solve(jump_prob,Tsit5())
+
+# test for https://discourse.julialang.org/t/differentialequations-jl-package-variable-rate-jumps-with-complex-variables/80366/2
+function f4(dx, x,p,t)
+  dx[1] = x[1]
+end
+rate4(x,p,t) = t
+function affect4!(integrator)
+  integrator.u[1] = integrator.u[1] * 0.5
+end
+jump = VariableRateJump(rate4, affect4!)
+x₀ = 1.0 + 0.0im
+Δt = (0.0, 6.0)
+prob = ODEProblem(f4, [x₀], Δt)
+jumpProblem = JumpProblem(prob, Direct(), jump)
+sol = solve(jumpProblem, Tsit5())


### PR DESCRIPTION
@ChrisRackauckas this was an attempt to fix

https://discourse.julialang.org/t/differentialequations-jl-package-variable-rate-jumps-with-complex-variables/80366/2

but tests are now failing (locally) in DiffEqBase with respect to callback conditions now being complex. 

Also, this has pointed out that there is no way in some places to get at the user-specified `rng` in `JumpProblem`, which means that we may have a situation where the rng for constant rate jumps is different than for variable rate jumps...